### PR TITLE
♻️ Refactor to use View Controllers at the Feature level

### DIFF
--- a/Stampede/Stampede-Tests/Common/LocalStorage/RepositoryListTests.swift
+++ b/Stampede/Stampede-Tests/Common/LocalStorage/RepositoryListTests.swift
@@ -55,44 +55,44 @@ class RepositoryListTests: XCTestCase {
     }
     
     func testProvidingRepositoriesInInitializerReturnsTheSame() {
-        let list = RepositoryList(repositories: Repository.someRepositories, provider: provider)
+        let list = BaseRepositoryList(repositories: Repository.someRepositories, provider: provider)
         let expectation = XCTestExpectation(description: "waiting on publisher")
         let publisher = list.fetchRepositoriesPublisher()
-        _ = publisher.sink { (_) in
+        _ = publisher.sink(receiveCompletion: { (_) in
            
-        } receiveValue: { (repositories) in
+        }, receiveValue: { (repositories) in
             XCTAssertEqual(repositories, Repository.someRepositories)
             expectation.fulfill()
-        }
+        })
         wait(for: [expectation], timeout: 10.0)
     }
  
     func testInitializerReadsFromFileIfNotProvidedInInitializer() {
-        _ = RepositoryList(provider: provider)
+        _ = BaseRepositoryList(provider: provider)
         XCTAssertTrue(provider.readCalled)
     }
     
     func testAddingRepositoryWritesToFile() {
-        let list = RepositoryList(provider: provider)
+        let list = BaseRepositoryList(provider: provider)
         list.addRepository(repository: Repository.someRepository)
         XCTAssertTrue(provider.writeCalled)
     }
     
     func testRemovingRepositoryWritesToFile() {
-        let list = RepositoryList(repositories: Repository.someRepositories, provider: provider)
+        let list = BaseRepositoryList(repositories: Repository.someRepositories, provider: provider)
         list.removeRepository(repository: Repository.someRepository)
         XCTAssertTrue(provider.writeCalled)
     }
     
     func testLoadWithNoFileSuppliesEmptyRepositories() {
         provider.exists = false
-        let list = RepositoryList(provider: provider)
+        let list = BaseRepositoryList(provider: provider)
         expectEmptyRepositoriesList(list)
     }
     
     func testCanHandleNotFindingUsersDocumentsPath() {
         provider.urls = []
-        let list = RepositoryList(provider: provider)
+        let list = BaseRepositoryList(provider: provider)
         list.addRepository(repository: Repository.someRepository)
         list.removeRepository(repository: Repository.someRepository)
         expectEmptyRepositoriesList(list)
@@ -101,12 +101,12 @@ class RepositoryListTests: XCTestCase {
     private func expectEmptyRepositoriesList(_ list: RepositoryList) {
         let expectation = XCTestExpectation(description: "waiting on publisher")
         let publisher = list.fetchRepositoriesPublisher()
-        _ = publisher.sink { (_) in
+        _ = publisher.sink(receiveCompletion: { (_) in
            
-        } receiveValue: { (repositories) in
+        }, receiveValue: { (repositories) in
             XCTAssertEqual(repositories.count, 0)
             expectation.fulfill()
-        }
+        })
         wait(for: [expectation], timeout: 10.0)
     }
 }

--- a/Stampede/Stampede-Tests/Features/Build/BuildFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Build/BuildFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class BuildFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(BuildFeature_Previews.previews,
-                   title: "BuildFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Build/BuildTask/BuildTaskFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Build/BuildTask/BuildTaskFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class BuildTaskFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(BuildTaskFeature_Previews.previews,
-                   title: "BuildTaskFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/History/Builds/HistoryBuildsFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/History/Builds/HistoryBuildsFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class HistoryBuildsFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(HistoryBuildsFeature_Previews.previews,
-                   title: "HistoryBuildsFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/History/Tasks/HistoryTasksFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/History/Tasks/HistoryTasksFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class HistoryTasksFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(HistoryTasksFeature_Previews.previews,
-                   title: "HistoryTasksFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
@@ -13,11 +13,13 @@ class MainFeatureTests: XCTestCase {
     
     var mainFeature: MainFeature!
     var window: UIWindow!
-    var dependencies = FixtureDependencies()
+    var dependencies: Dependencies!
+    var repositoryList = RepositoryListFixture()
     
     override func setUp() {
         super.setUp()
         window = UIWindow()
+        dependencies = Dependencies(repositoryList: repositoryList)
         mainFeature = MainFeature(dependencies: dependencies)
     }
 
@@ -27,12 +29,12 @@ class MainFeatureTests: XCTestCase {
     }
     
     func testFeatureCanCreateAChildViewController() {
-        loadView()
-        XCTAssertGreaterThan(mainFeature.view.subviews.count, 0)
+        capture(mainFeature, title: "MainFeature")
     }
     
     func testWhenViewAppearsThenViewModelAssignedAPublisher() {
         loadView()
+        XCTAssertTrue(repositoryList.fetchRepositoriesPublisherCalled)
     }
     
     private func loadView() {

--- a/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
@@ -11,8 +11,5 @@ import XCTest
 
 class MainFeatureTests: XCTestCase {
 
-    func testCapturePreviews() {
-        capture(MainFeature_Previews.previews,
-                   title: "MainFeature_Previews")
-    }
+    // TODO: What kind of tests do we want here?
 }

--- a/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
@@ -9,4 +9,34 @@
 import XCTest
 @testable import Stampede
 
-class MainFeatureTests: XCTestCase { }
+class MainFeatureTests: XCTestCase {
+    
+    var mainFeature: MainFeature!
+    var window: UIWindow!
+    var dependencies = FixtureDependencies()
+    
+    override func setUp() {
+        super.setUp()
+        window = UIWindow()
+        mainFeature = MainFeature(dependencies: dependencies)
+    }
+
+    override func tearDown() {
+        window = nil
+        super.tearDown()
+    }
+    
+    func testFeatureCanCreateAChildViewController() {
+        loadView()
+        XCTAssertGreaterThan(mainFeature.view.subviews.count, 0)
+    }
+    
+    func testWhenViewAppearsThenViewModelAssignedAPublisher() {
+        loadView()
+    }
+    
+    private func loadView() {
+        window.addSubview(mainFeature.view)
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Main/MainFeatureTests.swift
@@ -9,7 +9,4 @@
 import XCTest
 @testable import Stampede
 
-class MainFeatureTests: XCTestCase {
-
-    // TODO: What kind of tests do we want here?
-}
+class MainFeatureTests: XCTestCase { }

--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class MonitorActiveBuildsFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(MonitorActiveBuildsFeature_Previews.previews,
-                   title: "MonitorActiveBuildsFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class MonitorActiveTasksFeatureTests: XCTestCase {
-
-    func testViewPreviews() {
-        capture(MonitorActiveTasksFeature_Previews.previews,
-                title: "MonitorActiveTasksFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorQueues/MonitorQueuesFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorQueues/MonitorQueuesFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class MonitorQueuesFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(MonitorQueuesFeature_Previews.previews,
-                   title: "MonitorQueuesFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Repositories/Repository/RepositoryFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Repositories/Repository/RepositoryFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class RepositoryFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(RepositoryFeature_Previews.previews,
-                   title: "RepositoryFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Repositories/Repository/RepositoryFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Repositories/Repository/RepositoryFeatureTests.swift
@@ -10,4 +10,25 @@ import XCTest
 @testable import Stampede
 
 class RepositoryFeatureTests: XCTestCase {
+
+    var repositoryFeature: RepositoryFeature!
+    var window: UIWindow!
+    var dependencies: Dependencies!
+    var fixtureProvider = StampedeServiceFixtureProvider()
+
+    override func setUp() {
+        super.setUp()
+        window = UIWindow()
+        dependencies = Dependencies(serviceProvider: fixtureProvider)
+        repositoryFeature = RepositoryFeature(dependencies: dependencies, repository: Repository.someRepository)
+    }
+
+    override func tearDown() {
+        window = nil
+        super.tearDown()
+    }
+
+    func testFeatureCanCreateAChildViewController() {
+        capture(repositoryFeature, title: "RepositoryFeature")
+    }
 }

--- a/Stampede/Stampede-Tests/Features/Settings/Info/SettingsInfoFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Info/SettingsInfoFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class SettingsInfoFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(SettingsInfoFeature_Previews.previews,
-                   title: "SettingsInfoFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Settings/Notifications/SettingsNotificationsFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Notifications/SettingsNotificationsFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class SettingsNotificationsFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(SettingsNotificationFeature_Previews.previews,
-                   title: "SettingsNotificationFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeatureTests.swift
@@ -10,6 +10,4 @@ import XCTest
 @testable import Stampede
 
 class SelectRepositoryFeatureTests: XCTestCase {
-
-
 }

--- a/Stampede/Stampede-Tests/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeatureTests.swift
@@ -11,8 +11,5 @@ import XCTest
 
 class SelectRepositoryFeatureTests: XCTestCase {
 
-    func testCapturePreviews() {
-        capture(SelectRepositoryFeature_Previews.previews,
-                   title: "SelectRepositoryFeature_Previews")
-    }
+
 }

--- a/Stampede/Stampede-Tests/Features/Settings/Repositories/SettingsRepositoriesFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Repositories/SettingsRepositoriesFeatureTests.swift
@@ -9,10 +9,4 @@
 import XCTest
 @testable import Stampede
 
-class SettingsRepositoriesFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(SettingsRepositoriesFeature_Previews.previews,
-                   title: "SettingsRepositoriesFeature_Previews")
-    }
-}
+class SettingsRepositoriesFeatureTests: XCTestCase { }

--- a/Stampede/Stampede-Tests/Features/Settings/StampedeServer/SettingsStampedeServerFeatureTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/StampedeServer/SettingsStampedeServerFeatureTests.swift
@@ -10,9 +10,4 @@ import XCTest
 @testable import Stampede
 
 class SettingsStampedeServerFeatureTests: XCTestCase {
-
-    func testCapturePreviews() {
-        capture(SettingsStampedeServerFeature_Previews.previews,
-                   title: "SettingsStampedeServerFeature_Previews")
-    }
 }

--- a/Stampede/Stampede-Tests/Helpers/XCTestCase+Extension.swift
+++ b/Stampede/Stampede-Tests/Helpers/XCTestCase+Extension.swift
@@ -30,6 +30,23 @@ extension XCTestCase {
             add(attachment)
         }
     }
+
+    func capture(_ feature: UIViewController, title: String) {
+        let window = UIWindow()
+        window.rootViewController = feature
+//        window.addSubview(feature.view)
+        RunLoop.current.run(until: Date())
+        UIGraphicsBeginImageContextWithOptions(feature.view.bounds.size, feature.view.isOpaque, 0)
+        feature.view.drawHierarchy(in: feature.view.bounds, afterScreenUpdates: true)
+        let snapshotImage: UIImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        window.rootViewController = nil
+
+        let attachment = XCTAttachment(image: snapshotImage)
+        attachment.name = title
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
     
     func captureScreen(title: String) {
         let screenshot = XCUIScreen.main.screenshot()

--- a/Stampede/Stampede-UITests/Main/ScenarioMainScreen+Extension.swift
+++ b/Stampede/Stampede-UITests/Main/ScenarioMainScreen+Extension.swift
@@ -31,42 +31,42 @@ extension ScenarioMainScreen {
     }
 
     func thenTheMonitorLiveButtonIsDisplayed() {
-        waitForButton("monitor-live")
+        waitForButton("Live")
     }
 
     func thenTheMonitorActiveBuildsButtonIsDisplayed() {
-        waitForButton("monitor-active-builds")
+        waitForButton("Active Builds")
     }
 
     func thenTheMonitorActiveTasksButtonIsDisplayed() {
-        waitForButton("monitor-active-tasks")
+        waitForButton("Active Tasks")
     }
 
     func thenTheMonitorQueuesButtonIsDisplayed() {
-        waitForButton("monitor-queues")
+        waitForButton("Queues")
     }
 
     func thenTheHistoryBuildsButtonIsDisplayed() {
-        waitForButton("history-builds")
+        waitForButton("Builds")
     }
 
     func thenTheHistoryTasksButtonIsDisplayed() {
-        waitForButton("history-tasks")
+        waitForButton("Tasks")
     }
 
     func thenTheSettingsStampedeServerButtonIsDisplayed() {
-        waitForButton("settings-stampede-server")
+        waitForButton("Stampede Server")
     }
 
     func thenTheSettingsRepositoriesButtonIsDisplayed() {
-        waitForButton("settings-repositories")
+        waitForButton("Repositories")
     }
 
     func thenTheSettigsNotificationsButtonIsDisplayed() {
-        waitForButton("settings-notifications")
+        waitForButton("Notifications")
     }
 
     func thenTheSettingsInfoButtonIsDisplayed() {
-        waitForButton("settings-info")
+        waitForButton("Info")
     }
 }

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		94B571FE24BBBECD00CA13A4 /* StampedeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B571EA24BBBECD00CA13A4 /* StampedeService.swift */; };
 		94C0908D253485E8001E0B37 /* FeatureRouteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C0908C253485E8001E0B37 /* FeatureRouteCell.swift */; };
 		94C0909225348923001E0B37 /* FavoriteRepositoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C0909125348923001E0B37 /* FavoriteRepositoryCell.swift */; };
+		94C090972534A774001E0B37 /* RepositoryListFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C090962534A774001E0B37 /* RepositoryListFixture.swift */; };
 		94D4FFE72517FA0D0011AAB7 /* BuildKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D4FFE62517FA0D0011AAB7 /* BuildKeyTests.swift */; };
 		94DB4DFF247C47B8001EF693 /* NetworkErrorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB4DFE247C47B8001EF693 /* NetworkErrorViewTests.swift */; };
 		94DB4E03247C95AA001EF693 /* RepositoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB4E02247C95AA001EF693 /* RepositoryViewModel.swift */; };
@@ -233,6 +234,7 @@
 		94B571EA24BBBECD00CA13A4 /* StampedeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StampedeService.swift; sourceTree = "<group>"; };
 		94C0908C253485E8001E0B37 /* FeatureRouteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureRouteCell.swift; sourceTree = "<group>"; };
 		94C0909125348923001E0B37 /* FavoriteRepositoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRepositoryCell.swift; sourceTree = "<group>"; };
+		94C090962534A774001E0B37 /* RepositoryListFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListFixture.swift; sourceTree = "<group>"; };
 		94D4FFE62517FA0D0011AAB7 /* BuildKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildKeyTests.swift; sourceTree = "<group>"; };
 		94DB4DFE247C47B8001EF693 /* NetworkErrorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorViewTests.swift; sourceTree = "<group>"; };
 		94DB4E02247C95AA001EF693 /* RepositoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewModel.swift; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 			children = (
 				C3F76680245B0F300022E485 /* StampedeDefaults.swift */,
 				94FE1F4624FB081500AE4ED4 /* RepositoryList.swift */,
+				94C090962534A774001E0B37 /* RepositoryListFixture.swift */,
 			);
 			path = LocalStorage;
 			sourceTree = "<group>";
@@ -1392,6 +1395,7 @@
 				C3CA2E2224BA9F600086B71D /* SettingsNotificationsView.swift in Sources */,
 				C3816C80248702AB00E6980B /* MonitorActiveTasksFeature.swift in Sources */,
 				C30DBF9D252D2B4500021863 /* TimeInterval+Extension.swift in Sources */,
+				94C090972534A774001E0B37 /* RepositoryListFixture.swift in Sources */,
 				94FE1F4E24FB190200AE4ED4 /* SelectRepositoryViewModel.swift in Sources */,
 				C30DC0072533B4F900021863 /* Router.swift in Sources */,
 				94FE1F4524FAF52400AE4ED4 /* MonitorActiveTasksViewModel.swift in Sources */,

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -67,6 +67,10 @@
 		C30DBF95252D297700021863 /* DateExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBF94252D297700021863 /* DateExtensionTests.swift */; };
 		C30DBF9D252D2B4500021863 /* TimeInterval+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBF9C252D2B4500021863 /* TimeInterval+Extension.swift */; };
 		C30DBFA2252D306B00021863 /* TimeIntervalExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFA1252D306B00021863 /* TimeIntervalExtensionTests.swift */; };
+		C30DBFDE2532236C00021863 /* BaseFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFDD2532236C00021863 /* BaseFeature.swift */; };
+		C30DBFE6253223E500021863 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFE5253223E500021863 /* UIView+Extension.swift */; };
+		C30DBFEE25322D9500021863 /* MainNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFED25322D9500021863 /* MainNavigationController.swift */; };
+		C30DBFF32532308900021863 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFF22532308900021863 /* Dependencies.swift */; };
 		C3126DA023BED27F00AC542F /* PrimaryLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3126D9F23BED27F00AC542F /* PrimaryLabel.swift */; };
 		C3126DA223BED33400AC542F /* SecondaryLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3126DA123BED33400AC542F /* SecondaryLabel.swift */; };
 		C3126DA523BED39C00AC542F /* CurrentTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3126DA423BED39C00AC542F /* CurrentTheme.swift */; };
@@ -239,6 +243,10 @@
 		C30DBF94252D297700021863 /* DateExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionTests.swift; sourceTree = "<group>"; };
 		C30DBF9C252D2B4500021863 /* TimeInterval+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Extension.swift"; sourceTree = "<group>"; };
 		C30DBFA1252D306B00021863 /* TimeIntervalExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalExtensionTests.swift; sourceTree = "<group>"; };
+		C30DBFDD2532236C00021863 /* BaseFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseFeature.swift; sourceTree = "<group>"; };
+		C30DBFE5253223E500021863 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
+		C30DBFED25322D9500021863 /* MainNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavigationController.swift; sourceTree = "<group>"; };
+		C30DBFF22532308900021863 /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
 		C3126D9F23BED27F00AC542F /* PrimaryLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryLabel.swift; sourceTree = "<group>"; };
 		C3126DA123BED33400AC542F /* SecondaryLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryLabel.swift; sourceTree = "<group>"; };
 		C3126DA423BED39C00AC542F /* CurrentTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTheme.swift; sourceTree = "<group>"; };
@@ -457,6 +465,7 @@
 				9438376F2468713E00A90FF4 /* View+Extension.swift */,
 				C30DBF8E252D28A200021863 /* Date+Extension.swift */,
 				C30DBF9C252D2B4500021863 /* TimeInterval+Extension.swift */,
+				C30DBFE5253223E500021863 /* UIView+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -604,6 +613,8 @@
 				946DAD2A23BEC7C200053335 /* ComponentViews */,
 				944FD36223AE70AD001A9FF8 /* Extensions */,
 				94655E76236E378C00C3DE2F /* LocalStorage */,
+				C30DBFDD2532236C00021863 /* BaseFeature.swift */,
+				C30DBFF22532308900021863 /* Dependencies.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -785,6 +796,7 @@
 				C35D51AF2353C5DF00FDA4A8 /* MainView.swift */,
 				C3F83EC5239407290057A0FB /* MainFeature.swift */,
 				C38C888D24BA1B8F00F6E6C9 /* MainViewModel.swift */,
+				C30DBFED25322D9500021863 /* MainNavigationController.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -1286,10 +1298,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				94B571F924BBBECD00CA13A4 /* StampedeServiceNetworkProvider.swift in Sources */,
+				C30DBFE6253223E500021863 /* UIView+Extension.swift in Sources */,
 				C3AD03AD24887C4200EB881F /* QueueGaugeView.swift in Sources */,
 				C3081ACA24563CBE000C20F1 /* RepositoryView.swift in Sources */,
 				C38C889424BA224300F6E6C9 /* SettingsInfoViewModel.swift in Sources */,
 				C3CA2E1324BA9ED70086B71D /* HistoryTasksFeature.swift in Sources */,
+				C30DBFDE2532236C00021863 /* BaseFeature.swift in Sources */,
 				C38C889224BA223200F6E6C9 /* SettingsInfoView.swift in Sources */,
 				C3AD03A924885D4600EB881F /* MonitorLiveFeature.swift in Sources */,
 				9421332E24C33F820043FBD2 /* BuildKey.swift in Sources */,
@@ -1313,6 +1327,7 @@
 				C3349EB62350A92B00273730 /* AppDelegate.swift in Sources */,
 				94B571F224BBBECD00CA13A4 /* QueueSummary.swift in Sources */,
 				C38C889024BA222500F6E6C9 /* SettingsInfoFeature.swift in Sources */,
+				C30DBFF32532308900021863 /* Dependencies.swift in Sources */,
 				9438376E246859E400A90FF4 /* DevicePreviewer.swift in Sources */,
 				C3CA2E0E24BA9EB50086B71D /* HistoryBuildsView.swift in Sources */,
 				94DB4E03247C95AA001EF693 /* RepositoryViewModel.swift in Sources */,
@@ -1333,6 +1348,7 @@
 				C30DBF8F252D28A200021863 /* Date+Extension.swift in Sources */,
 				C3AD03AB24885E4300EB881F /* MonitorLiveViewModel.swift in Sources */,
 				94E913AF24BB512B0056A150 /* BuildTaskFeature.swift in Sources */,
+				C30DBFEE25322D9500021863 /* MainNavigationController.swift in Sources */,
 				C34755EA24FC8446009B1FBF /* RepositoryCell.swift in Sources */,
 				C3349EB82350A92B00273730 /* SceneDelegate.swift in Sources */,
 				94B571EC24BBBECD00CA13A4 /* ConfigDefaults.swift in Sources */,

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		C30DBFE6253223E500021863 /* UIView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFE5253223E500021863 /* UIView+Extension.swift */; };
 		C30DBFEE25322D9500021863 /* MainNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFED25322D9500021863 /* MainNavigationController.swift */; };
 		C30DBFF32532308900021863 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DBFF22532308900021863 /* Dependencies.swift */; };
+		C30DC0072533B4F900021863 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30DC0062533B4F900021863 /* Router.swift */; };
 		C3126DA023BED27F00AC542F /* PrimaryLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3126D9F23BED27F00AC542F /* PrimaryLabel.swift */; };
 		C3126DA223BED33400AC542F /* SecondaryLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3126DA123BED33400AC542F /* SecondaryLabel.swift */; };
 		C3126DA523BED39C00AC542F /* CurrentTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3126DA423BED39C00AC542F /* CurrentTheme.swift */; };
@@ -249,6 +250,7 @@
 		C30DBFE5253223E500021863 /* UIView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extension.swift"; sourceTree = "<group>"; };
 		C30DBFED25322D9500021863 /* MainNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavigationController.swift; sourceTree = "<group>"; };
 		C30DBFF22532308900021863 /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
+		C30DC0062533B4F900021863 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		C3126D9F23BED27F00AC542F /* PrimaryLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryLabel.swift; sourceTree = "<group>"; };
 		C3126DA123BED33400AC542F /* SecondaryLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondaryLabel.swift; sourceTree = "<group>"; };
 		C3126DA423BED39C00AC542F /* CurrentTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentTheme.swift; sourceTree = "<group>"; };
@@ -618,6 +620,7 @@
 				C30DBFDD2532236C00021863 /* BaseFeature.swift */,
 				C30DBFF22532308900021863 /* Dependencies.swift */,
 				9455103E253383A7007A1299 /* Route.swift */,
+				C30DC0062533B4F900021863 /* Router.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1382,6 +1385,7 @@
 				C3816C80248702AB00E6980B /* MonitorActiveTasksFeature.swift in Sources */,
 				C30DBF9D252D2B4500021863 /* TimeInterval+Extension.swift in Sources */,
 				94FE1F4E24FB190200AE4ED4 /* SelectRepositoryViewModel.swift in Sources */,
+				C30DC0072533B4F900021863 /* Router.swift in Sources */,
 				94FE1F4524FAF52400AE4ED4 /* MonitorActiveTasksViewModel.swift in Sources */,
 				C347521024FAF819000F48B7 /* MonitorQueuesViewModel.swift in Sources */,
 				C3CA2E1724BA9EEE0086B71D /* HistoryTasksViewModel.swift in Sources */,

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		94B571FB24BBBECD00CA13A4 /* StampedeServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B571E724BBBECD00CA13A4 /* StampedeServiceProvider.swift */; };
 		94B571FC24BBBECD00CA13A4 /* StampedeAPIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B571E824BBBECD00CA13A4 /* StampedeAPIEndpoint.swift */; };
 		94B571FE24BBBECD00CA13A4 /* StampedeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B571EA24BBBECD00CA13A4 /* StampedeService.swift */; };
+		94C0908D253485E8001E0B37 /* FeatureRouteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C0908C253485E8001E0B37 /* FeatureRouteCell.swift */; };
+		94C0909225348923001E0B37 /* FavoriteRepositoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C0909125348923001E0B37 /* FavoriteRepositoryCell.swift */; };
 		94D4FFE72517FA0D0011AAB7 /* BuildKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D4FFE62517FA0D0011AAB7 /* BuildKeyTests.swift */; };
 		94DB4DFF247C47B8001EF693 /* NetworkErrorViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB4DFE247C47B8001EF693 /* NetworkErrorViewTests.swift */; };
 		94DB4E03247C95AA001EF693 /* RepositoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94DB4E02247C95AA001EF693 /* RepositoryViewModel.swift */; };
@@ -229,6 +231,8 @@
 		94B571E724BBBECD00CA13A4 /* StampedeServiceProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StampedeServiceProvider.swift; sourceTree = "<group>"; };
 		94B571E824BBBECD00CA13A4 /* StampedeAPIEndpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StampedeAPIEndpoint.swift; sourceTree = "<group>"; };
 		94B571EA24BBBECD00CA13A4 /* StampedeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StampedeService.swift; sourceTree = "<group>"; };
+		94C0908C253485E8001E0B37 /* FeatureRouteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureRouteCell.swift; sourceTree = "<group>"; };
+		94C0909125348923001E0B37 /* FavoriteRepositoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRepositoryCell.swift; sourceTree = "<group>"; };
 		94D4FFE62517FA0D0011AAB7 /* BuildKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildKeyTests.swift; sourceTree = "<group>"; };
 		94DB4DFE247C47B8001EF693 /* NetworkErrorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorViewTests.swift; sourceTree = "<group>"; };
 		94DB4E02247C95AA001EF693 /* RepositoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewModel.swift; sourceTree = "<group>"; };
@@ -653,6 +657,8 @@
 				C34755EF24FC88E2009B1FBF /* QueueSummaryCell.swift */,
 				944EF65824FD200C00357E9E /* RepositoryBuildCell.swift */,
 				C3D150872506569B0080FC53 /* BuildKeyCell.swift */,
+				94C0908C253485E8001E0B37 /* FeatureRouteCell.swift */,
+				94C0909125348923001E0B37 /* FavoriteRepositoryCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -1315,6 +1321,7 @@
 				9421332E24C33F820043FBD2 /* BuildKey.swift in Sources */,
 				94B571F324BBBECD00CA13A4 /* Repository.swift in Sources */,
 				C3804FD0248EEB55008A302B /* QueueChartView.swift in Sources */,
+				94C0908D253485E8001E0B37 /* FeatureRouteCell.swift in Sources */,
 				C3816C7F248702AB00E6980B /* MonitorActiveTasksView.swift in Sources */,
 				94B571F424BBBECD00CA13A4 /* Queue.swift in Sources */,
 				94B571EF24BBBECD00CA13A4 /* WorkerStatus.swift in Sources */,
@@ -1370,6 +1377,7 @@
 				C3816C79248702AB00E6980B /* MonitorActiveBuildsFeature.swift in Sources */,
 				94B571D424BBBEC200CA13A4 /* Constants.swift in Sources */,
 				C3CA2E1524BA9EE30086B71D /* HistoryTasksView.swift in Sources */,
+				94C0909225348923001E0B37 /* FavoriteRepositoryCell.swift in Sources */,
 				C3816C7D248702AB00E6980B /* MonitorQueuesView.swift in Sources */,
 				C34755EC24FC85BD009B1FBF /* BuildStatusCell.swift in Sources */,
 				94FE1F4724FB081500AE4ED4 /* RepositoryList.swift in Sources */,

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		943C3DB42524A90F00C35FB6 /* RepositoryListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 943C3DB32524A90F00C35FB6 /* RepositoryListTests.swift */; };
 		944EF65724FD1A8300357E9E /* StampedeServiceFixtureProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944EF65624FD1A8300357E9E /* StampedeServiceFixtureProvider.swift */; };
 		944EF65924FD200C00357E9E /* RepositoryBuildCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 944EF65824FD200C00357E9E /* RepositoryBuildCell.swift */; };
+		9455103F253383A7007A1299 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9455103E253383A7007A1299 /* Route.swift */; };
 		946F3A7B252C99AF008C20EF /* BuildViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946F3A7A252C99AF008C20EF /* BuildViewModelTests.swift */; };
 		946F3A7F252CA408008C20EF /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B1D62A23AE8598002CCE66 /* XCTestCase+Extension.swift */; };
 		949CC96A2517840F00BEC54E /* RepositoryBuildTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949CC9692517840F00BEC54E /* RepositoryBuildTests.swift */; };
@@ -202,6 +203,7 @@
 		943C3DB32524A90F00C35FB6 /* RepositoryListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListTests.swift; sourceTree = "<group>"; };
 		944EF65624FD1A8300357E9E /* StampedeServiceFixtureProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampedeServiceFixtureProvider.swift; sourceTree = "<group>"; };
 		944EF65824FD200C00357E9E /* RepositoryBuildCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryBuildCell.swift; sourceTree = "<group>"; };
+		9455103E253383A7007A1299 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		946F3A7A252C99AF008C20EF /* BuildViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildViewModelTests.swift; sourceTree = "<group>"; };
 		948DCFD4239006B00078B23F /* BuildView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildView.swift; sourceTree = "<group>"; };
 		949CC9692517840F00BEC54E /* RepositoryBuildTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryBuildTests.swift; sourceTree = "<group>"; };
@@ -615,6 +617,7 @@
 				94655E76236E378C00C3DE2F /* LocalStorage */,
 				C30DBFDD2532236C00021863 /* BaseFeature.swift */,
 				C30DBFF22532308900021863 /* Dependencies.swift */,
+				9455103E253383A7007A1299 /* Route.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1338,6 +1341,7 @@
 				C3081AC724563CBE000C20F1 /* BuildViewModel.swift in Sources */,
 				C34755EE24FC878B009B1FBF /* TaskStatusCell.swift in Sources */,
 				C3126DA023BED27F00AC542F /* PrimaryLabel.swift in Sources */,
+				9455103F253383A7007A1299 /* Route.swift in Sources */,
 				944EF65724FD1A8300357E9E /* StampedeServiceFixtureProvider.swift in Sources */,
 				94B571EE24BBBECD00CA13A4 /* ConfigOverrides.swift in Sources */,
 				C38C888624BA155A00F6E6C9 /* SettingsStampedeServerViewModel.swift in Sources */,

--- a/Stampede/Stampede/Common/BaseFeature.swift
+++ b/Stampede/Stampede/Common/BaseFeature.swift
@@ -1,0 +1,41 @@
+//
+//  BaseFeature.swift
+//  Stampede
+//
+//  Created by David House on 10/10/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import SwiftUI
+
+class BaseFeature<T>: UIViewController {
+
+    let dependencies: T
+
+    init(dependencies: T) {
+        self.dependencies = dependencies
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    lazy var childViewController: UIViewController = {
+        makeChildViewController()
+    }()
+
+    func makeChildViewController() -> UIViewController {
+        UIHostingController(rootView: EmptyView())
+    }
+
+    override func viewDidLoad() {
+        addChild(childViewController)
+        childViewController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(childViewController.view)
+        childViewController.didMove(toParent: self)
+        childViewController.view.pinEdges(to: view)
+    }
+}

--- a/Stampede/Stampede/Common/BaseFeature.swift
+++ b/Stampede/Stampede/Common/BaseFeature.swift
@@ -12,13 +12,13 @@ import SwiftUI
 import Combine
 import HouseKit
 
-class BaseFeature<D>: UIViewController {
+class BaseFeature: UIViewController {
 
     // MARK: - Public properties
 
-    let dependencies: D
+    let dependencies: Dependencies
 
-    init(dependencies: D) {
+    init(dependencies: Dependencies) {
         self.dependencies = dependencies
         super.init(nibName: nil, bundle: nil)
     }
@@ -41,5 +41,22 @@ class BaseFeature<D>: UIViewController {
         view.addSubview(childViewController.view)
         childViewController.didMove(toParent: self)
         childViewController.view.pinEdges(to: view)
+    }
+    
+    func push(to route: Route) {
+        let destination = route.featureController(dependencies)
+        navigationController?.pushViewController(destination, animated: true)
+    }
+    
+    func present(with route: Route) {
+        let destination = route.featureController(dependencies)
+        present(destination, animated: true, completion: {})
+    }
+}
+
+extension BaseFeature: Router {
+    
+    func route(to route: Route) {
+        push(to: route)
     }
 }

--- a/Stampede/Stampede/Common/BaseFeature.swift
+++ b/Stampede/Stampede/Common/BaseFeature.swift
@@ -9,12 +9,16 @@
 import Foundation
 import UIKit
 import SwiftUI
+import Combine
+import HouseKit
 
-class BaseFeature<T>: UIViewController {
+class BaseFeature<D>: UIViewController {
 
-    let dependencies: T
+    // MARK: - Public properties
 
-    init(dependencies: T) {
+    let dependencies: D
+
+    init(dependencies: D) {
         self.dependencies = dependencies
         super.init(nibName: nil, bundle: nil)
     }

--- a/Stampede/Stampede/Common/BaseFeature.swift
+++ b/Stampede/Stampede/Common/BaseFeature.swift
@@ -17,10 +17,13 @@ class BaseFeature: UIViewController {
     // MARK: - Public properties
 
     let dependencies: Dependencies
+    let router: Router
 
     init(dependencies: Dependencies) {
         self.dependencies = dependencies
+        router = Router()
         super.init(nibName: nil, bundle: nil)
+        router.delegate = self
     }
 
     required init?(coder: NSCoder) {
@@ -42,21 +45,24 @@ class BaseFeature: UIViewController {
         childViewController.didMove(toParent: self)
         childViewController.view.pinEdges(to: view)
     }
-    
-    func push(to route: Route) {
+}
+
+extension BaseFeature: RouterDelegate {
+    func shouldRoute(to: Route) -> Bool {
+        return true
+    }
+
+    func routeMethod(for: Route) -> RouteMethod {
+        return .push
+    }
+
+    func push(route: Route) {
         let destination = route.featureController(dependencies)
         navigationController?.pushViewController(destination, animated: true)
     }
-    
-    func present(with route: Route) {
+
+    func present(route: Route) {
         let destination = route.featureController(dependencies)
         present(destination, animated: true, completion: {})
-    }
-}
-
-extension BaseFeature: Router {
-    
-    func route(to route: Route) {
-        push(to: route)
     }
 }

--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildStatusCell.swift
@@ -10,24 +10,31 @@ import SwiftUI
 
 struct BuildStatusCell: View {
 
+    @EnvironmentObject var router: Router
+    
     let buildStatus: BuildStatus
 
     var body: some View {
-        HStack {
-            switch buildStatus.statusIndicator {
-            case .inProgress:
-                CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
-            case .failure:
-                CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
-            case .success:
-                CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
+        Button(action: {
+            router.route(to: .buildDetails(buildStatus))
+        }, label: {
+            HStack {
+                switch buildStatus.statusIndicator {
+                case .inProgress:
+                    CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
+                case .failure:
+                    CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
+                case .success:
+                    CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
+                }
+                VStack(alignment: .leading) {
+                    PrimaryLabel(buildStatus.buildIdentifier)
+                }
+                Spacer()
+                ValueLabel(buildStatus.startedAgo)
+                Image(systemName: "chevron.right")
             }
-            VStack(alignment: .leading) {
-                PrimaryLabel(buildStatus.buildIdentifier)
-            }
-            Spacer()
-            ValueLabel(buildStatus.startedAgo)
-        }
+        })
     }
 }
 

--- a/Stampede/Stampede/Common/ComponentViews/Cells/FavoriteRepositoryCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/FavoriteRepositoryCell.swift
@@ -1,15 +1,14 @@
 //
-//  RepositoryCell.swift
+//  FavoriteRepositoryCell.swift
 //  Stampede
 //
-//  Created by David House on 8/30/20.
+//  Created by David House on 10/12/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
 
 import SwiftUI
 
-struct RepositoryCell: View {
-
+struct FavoriteRepositoryCell: View {
     let repository: Repository
 
     var body: some View {
@@ -19,16 +18,16 @@ struct RepositoryCell: View {
                 SecondaryLabel(repository.repository)
             }
             Spacer()
-            Image(systemName: "chevron.right")
+            Image(systemName: "star.fill").foregroundColor(/*@START_MENU_TOKEN@*/.blue/*@END_MENU_TOKEN@*/)
         }.accessibility(identifier: repository.id)
     }
 }
 
 #if DEBUG
-struct RepositoryCell_Previews: PreviewProvider {
+struct FavoriteRepositoryCell_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            RepositoryCell(repository: Repository.someRepository)
+            FavoriteRepositoryCell(repository: Repository.someRepository)
         }
     }
 }

--- a/Stampede/Stampede/Common/ComponentViews/Cells/FeatureRouteCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/FeatureRouteCell.swift
@@ -1,0 +1,38 @@
+//
+//  FeatureRouteCell.swift
+//  Stampede
+//
+//  Created by David House on 10/12/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import SwiftUI
+
+struct FeatureRouteCell: View {
+    
+    @EnvironmentObject var router: Router
+    
+    let title: String
+    let route: Route
+    
+    var body: some View {
+        Button(action: {
+            self.router.route(to: route)
+        }, label: {
+            HStack {
+                PrimaryLabel(title)
+                Spacer()
+                Image(systemName: "chevron.right")
+            }
+        })
+        .accessibility(identifier: title)
+    }
+}
+
+struct FeatureRouteCell_Previews: PreviewProvider {
+    static var previews: some View {
+        Previewer {
+            FeatureRouteCell(title: "Testing", route: .monitorActiveTasks)
+        }
+    }
+}

--- a/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
@@ -10,28 +10,35 @@ import SwiftUI
 
 struct TaskStatusCell: View {
 
+    @EnvironmentObject var router: Router
+    
     let taskStatus: TaskStatus
 
     var body: some View {
-        HStack {
-            switch taskStatus.status {
-            case "inProgress":
-                CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
-            default:
-                switch taskStatus.conclusion {
-                case "success":
-                    CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
+        Button(action: {
+            router.route(to: .taskDetails(taskStatus))
+        }, label: {
+            HStack {
+                switch taskStatus.status {
+                case "inProgress":
+                    CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
                 default:
-                    CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
+                    switch taskStatus.conclusion {
+                    case "success":
+                        CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
+                    default:
+                        CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
+                    }
                 }
+                VStack(alignment: .leading) {
+                    PrimaryLabel(taskStatus.task)
+                    SecondaryLabel(taskStatus.buildTitle ?? "")
+                }
+                Spacer()
+                ValueLabel(taskStatus.duration)
+                Image(systemName: "chevron.right")
             }
-            VStack(alignment: .leading) {
-                PrimaryLabel(taskStatus.task)
-                SecondaryLabel(taskStatus.buildTitle ?? "")
-            }
-            Spacer()
-            ValueLabel(taskStatus.duration)
-        }
+        })
     }
 }
 

--- a/Stampede/Stampede/Common/Dependencies.swift
+++ b/Stampede/Stampede/Common/Dependencies.swift
@@ -9,7 +9,14 @@
 import Foundation
 import SwiftUI
 
-class Dependencies {
+protocol Dependencies {
+    var defaults: StampedeDefaults { get }
+    var service: StampedeService { get }
+    var repositoryList: RepositoryList { get }
+    var theme: CurrentTheme { get }
+}
+
+class BaseDependencies: Dependencies {
     let defaults: StampedeDefaults = {
         return StampedeDefaults()
     }()
@@ -17,30 +24,50 @@ class Dependencies {
     let service: StampedeService
     
     let repositoryList: RepositoryList = {
-        #if DEBUG
-        if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"], stampedeServer == "fixtures" {
-                return RepositoryList(repositories: [Repository.someRepository])
-        }
-        #endif
-        return RepositoryList()
+        return BaseRepositoryList()
     }()
     let theme: CurrentTheme
 
+    init(serviceProvider: StampedeServiceProvider? = nil) {
+        theme = CurrentTheme()
+        if let serviceProvider = serviceProvider {
+            service = StampedeService(provider: serviceProvider)
+        } else {
+            #if DEBUG
+            if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"] {
+                if stampedeServer == "fixtures" {
+                    service = StampedeService(host: stampedeServer, provider: StampedeServiceFixtureProvider())
+                } else {
+                    service = StampedeService(host: stampedeServer, provider: StampedeServiceNetworkProvider(host: stampedeServer))
+                }
+            } else {
+                service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
+            }
+            #else
+            service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
+            #endif
+        }
+        defaults.hostSubject = service.hostPassthroughSubject
+    }
+}
+
+class FixtureDependencies: Dependencies {
+    let defaults: StampedeDefaults = {
+        return StampedeDefaults()
+    }()
+    
+    let service: StampedeService
+    
+    let repositoryList: RepositoryList = {
+        return RepositoryListFixture()
+    }()
+    let theme: CurrentTheme
+
+    let fixtureProvider = StampedeServiceFixtureProvider()
+    
     init() {
         theme = CurrentTheme()
-        #if DEBUG
-        if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"] {
-            if stampedeServer == "fixtures" {
-                service = StampedeService(host: stampedeServer, provider: StampedeServiceFixtureProvider())
-            } else {
-                service = StampedeService(host: stampedeServer, provider: StampedeServiceNetworkProvider(host: stampedeServer))
-            }
-        } else {
-            service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
-        }
-        #else
-        service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
-        #endif
+        service = StampedeService(host: "fixtures", provider: fixtureProvider)
         defaults.hostSubject = service.hostPassthroughSubject
     }
 }

--- a/Stampede/Stampede/Common/Dependencies.swift
+++ b/Stampede/Stampede/Common/Dependencies.swift
@@ -10,11 +10,37 @@ import Foundation
 import SwiftUI
 
 class Dependencies {
-    let repositoryList: RepositoryList
+    let defaults: StampedeDefaults = {
+        return StampedeDefaults()
+    }()
+    
+    let service: StampedeService
+    
+    let repositoryList: RepositoryList = {
+        #if DEBUG
+        if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"], stampedeServer == "fixtures" {
+                return RepositoryList(repositories: [Repository.someRepository])
+        }
+        #endif
+        return RepositoryList()
+    }()
     let theme: CurrentTheme
 
     init() {
-        repositoryList = RepositoryList()
         theme = CurrentTheme()
+        #if DEBUG
+        if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"] {
+            if stampedeServer == "fixtures" {
+                service = StampedeService(host: stampedeServer, provider: StampedeServiceFixtureProvider())
+            } else {
+                service = StampedeService(host: stampedeServer, provider: StampedeServiceNetworkProvider(host: stampedeServer))
+            }
+        } else {
+            service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
+        }
+        #else
+        service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
+        #endif
+        defaults.hostSubject = service.hostPassthroughSubject
     }
 }

--- a/Stampede/Stampede/Common/Dependencies.swift
+++ b/Stampede/Stampede/Common/Dependencies.swift
@@ -1,0 +1,20 @@
+//
+//  Dependencies.swift
+//  Stampede
+//
+//  Created by David House on 10/10/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+class Dependencies {
+    let repositoryList: RepositoryList
+    let theme: CurrentTheme
+
+    init() {
+        repositoryList = RepositoryList()
+        theme = CurrentTheme()
+    }
+}

--- a/Stampede/Stampede/Common/Dependencies.swift
+++ b/Stampede/Stampede/Common/Dependencies.swift
@@ -9,27 +9,18 @@
 import Foundation
 import SwiftUI
 
-protocol Dependencies {
-    var defaults: StampedeDefaults { get }
-    var service: StampedeService { get }
-    var repositoryList: RepositoryList { get }
-    var theme: CurrentTheme { get }
-}
-
-class BaseDependencies: Dependencies {
+class Dependencies {
     let defaults: StampedeDefaults = {
         return StampedeDefaults()
     }()
     
     let service: StampedeService
-    
-    let repositoryList: RepositoryList = {
-        return BaseRepositoryList()
-    }()
     let theme: CurrentTheme
+    let repositoryList: RepositoryList
 
-    init(serviceProvider: StampedeServiceProvider? = nil) {
+    init(serviceProvider: StampedeServiceProvider? = nil, repositoryList: RepositoryList = BaseRepositoryList()) {
         theme = CurrentTheme()
+        self.repositoryList = repositoryList
         if let serviceProvider = serviceProvider {
             service = StampedeService(provider: serviceProvider)
         } else {
@@ -47,27 +38,6 @@ class BaseDependencies: Dependencies {
             service = StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
             #endif
         }
-        defaults.hostSubject = service.hostPassthroughSubject
-    }
-}
-
-class FixtureDependencies: Dependencies {
-    let defaults: StampedeDefaults = {
-        return StampedeDefaults()
-    }()
-    
-    let service: StampedeService
-    
-    let repositoryList: RepositoryList = {
-        return RepositoryListFixture()
-    }()
-    let theme: CurrentTheme
-
-    let fixtureProvider = StampedeServiceFixtureProvider()
-    
-    init() {
-        theme = CurrentTheme()
-        service = StampedeService(host: "fixtures", provider: fixtureProvider)
         defaults.hostSubject = service.hostPassthroughSubject
     }
 }

--- a/Stampede/Stampede/Common/Extensions/UIView+Extension.swift
+++ b/Stampede/Stampede/Common/Extensions/UIView+Extension.swift
@@ -1,0 +1,19 @@
+//
+//  UIView+Extension.swift
+//  Stampede
+//
+//  Created by David House on 10/10/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIView {
+    func pinEdges(to other: UIView) {
+        leadingAnchor.constraint(equalTo: other.leadingAnchor).isActive = true
+        trailingAnchor.constraint(equalTo: other.trailingAnchor).isActive = true
+        topAnchor.constraint(equalTo: other.topAnchor).isActive = true
+        bottomAnchor.constraint(equalTo: other.bottomAnchor).isActive = true
+    }
+}

--- a/Stampede/Stampede/Common/Extensions/View+Extension.swift
+++ b/Stampede/Stampede/Common/Extensions/View+Extension.swift
@@ -22,6 +22,7 @@ extension View {
             .environmentObject(StampedeDefaults.someDefaults)
             .environmentObject(CurrentTheme())
             .environmentObject(RepositoryList())
+            .environmentObject(Router())
             .environmentObject(StampedeService(provider: StampedeServiceFixtureProvider()))
     }
     #endif

--- a/Stampede/Stampede/Common/Extensions/View+Extension.swift
+++ b/Stampede/Stampede/Common/Extensions/View+Extension.swift
@@ -21,7 +21,7 @@ extension View {
         return self
             .environmentObject(StampedeDefaults.someDefaults)
             .environmentObject(CurrentTheme())
-            .environmentObject(RepositoryList())
+            .environmentObject(RepositoryListFixture())
             .environmentObject(Router())
             .environmentObject(StampedeService(provider: StampedeServiceFixtureProvider()))
     }

--- a/Stampede/Stampede/Common/Extensions/View+Extension.swift
+++ b/Stampede/Stampede/Common/Extensions/View+Extension.swift
@@ -10,7 +10,12 @@ import Foundation
 import SwiftUI
 
 extension View {
-    
+
+    func dependenciesToEnvironment(_ dependencies: Dependencies) -> some View {
+        return self
+            .environmentObject(dependencies.theme)
+    }
+
     #if DEBUG
     func previewDependencies() -> some View {
         return self

--- a/Stampede/Stampede/Common/LocalStorage/RepositoryList.swift
+++ b/Stampede/Stampede/Common/LocalStorage/RepositoryList.swift
@@ -17,12 +17,20 @@ protocol RepositoryListProvider {
     func read(from: URL) throws -> Data
 }
 
-class RepositoryList: ObservableObject {
+protocol RepositoryList {
+    init(repositories: [Repository]?, provider: RepositoryListProvider)
+    func addRepository(repository: Repository)
+    func removeRepository(repository: Repository)
+    func removeRepositories(_ indexSet: IndexSet)
+    func fetchRepositoriesPublisher() -> AnyPublisher<[Repository], ServiceError>
+}
+
+class BaseRepositoryList: RepositoryList, ObservableObject {
     
     private let provider: RepositoryListProvider
     private var repositories: [Repository] = []
     
-    init(repositories: [Repository]? = nil, provider: RepositoryListProvider = FileManager.default) {
+    required init(repositories: [Repository]? = nil, provider: RepositoryListProvider = FileManager.default) {
         self.provider = provider
         if let repositories = repositories {
             self.repositories = repositories

--- a/Stampede/Stampede/Common/LocalStorage/RepositoryList.swift
+++ b/Stampede/Stampede/Common/LocalStorage/RepositoryList.swift
@@ -40,6 +40,11 @@ class RepositoryList: ObservableObject {
         repositories.removeAll(where: { $0.id == repository.id })
         save()
     }
+
+    func removeRepositories(_ indexSet: IndexSet) {
+        repositories.remove(atOffsets: indexSet)
+        save()
+    }
     
     func fetchRepositoriesPublisher() -> AnyPublisher<[Repository], ServiceError> {
         return AnyPublisher<[Repository], ServiceError>(Future<[Repository], ServiceError> { promise in

--- a/Stampede/Stampede/Common/LocalStorage/RepositoryListFixture.swift
+++ b/Stampede/Stampede/Common/LocalStorage/RepositoryListFixture.swift
@@ -1,0 +1,69 @@
+//
+//  RepositoryListFixture.swift
+//  Stampede
+//
+//  Created by David House on 10/12/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import Combine
+import HouseKit
+
+class RepositoryListFixture: RepositoryList, ObservableObject {
+    
+    private let provider: RepositoryListProvider
+    private var repositories: [Repository] = []
+
+    var addRepositoryCalled = false
+    var removeRepositoryCalled = false
+    var removeRepositoriesCalled = false
+    var fetchRepositoriesPublisherCalled = false
+    
+    required init(repositories: [Repository]? = nil, provider: RepositoryListProvider = RepositoryListFixtureProvider()) {
+        self.repositories = Repository.someRepositories
+        self.provider = provider
+    }
+    
+    func addRepository(repository: Repository) {
+        repositories.append(repository)
+        addRepositoryCalled = true
+    }
+    
+    func removeRepository(repository: Repository) {
+        repositories.removeAll(where: { $0.id == repository.id })
+        removeRepositoryCalled = true
+    }
+    
+    func removeRepositories(_ indexSet: IndexSet) {
+        repositories.remove(atOffsets: indexSet)
+        removeRepositoriesCalled = true
+    }
+    
+    func fetchRepositoriesPublisher() -> AnyPublisher<[Repository], ServiceError> {
+        fetchRepositoriesPublisherCalled = true
+        return AnyPublisher<[Repository], ServiceError>(Future<[Repository], ServiceError> { promise in
+                promise(.success(self.repositories))
+        })
+    }
+    
+    
+}
+
+class RepositoryListFixtureProvider: RepositoryListProvider {
+    func urls(for directory: FileManager.SearchPathDirectory, in domainMask: FileManager.SearchPathDomainMask) -> [URL] {
+        return []
+    }
+    
+    func fileExists(atPath path: String) -> Bool {
+        return true
+    }
+    
+    func write(_ data: Data, to: URL) throws {
+        
+    }
+    
+    func read(from: URL) throws -> Data {
+        return Data()
+    }
+}

--- a/Stampede/Stampede/Common/LocalStorage/RepositoryListFixture.swift
+++ b/Stampede/Stampede/Common/LocalStorage/RepositoryListFixture.swift
@@ -46,8 +46,6 @@ class RepositoryListFixture: RepositoryList, ObservableObject {
                 promise(.success(self.repositories))
         })
     }
-    
-    
 }
 
 class RepositoryListFixtureProvider: RepositoryListProvider {

--- a/Stampede/Stampede/Common/Route.swift
+++ b/Stampede/Stampede/Common/Route.swift
@@ -9,8 +9,9 @@
 import Foundation
 import UIKit
 
-protocol Router: class {
-    func route(to: Route)
+enum RouteMethod {
+    case push
+    case present
 }
 
 enum Route {

--- a/Stampede/Stampede/Common/Route.swift
+++ b/Stampede/Stampede/Common/Route.swift
@@ -1,0 +1,69 @@
+//
+//  Route.swift
+//  Stampede
+//
+//  Created by David House on 10/11/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+protocol Router: class {
+    func route(to: Route)
+}
+
+enum Route {
+    
+    // Repository and Builds
+    case repositoryDetails(_ repository: Repository)
+    case buildDetails(_ buildStatus: BuildStatus)
+    case taskDetails(_ task: TaskStatus)
+    
+    // Monitor
+    case monitorLive
+    case monitorActiveBuilds
+    case monitorActiveTasks
+    case monitorQueues
+    
+    // History
+    case historyTasks
+    case historyBuilds
+    
+    // Settings
+    case settingsStampedeServer
+    case settingsRepositories
+    case settingsNotifications
+    case settingsInfo
+    
+    func featureController(_ dependencies: Dependencies) -> UIViewController {
+        switch self {
+        case .repositoryDetails(let repository):
+            return RepositoryFeature.makeFeature(dependencies, repository: repository)
+        case .buildDetails(let buildStatus):
+            return BuildFeature.makeFeature(dependencies, build: buildStatus)
+        case .taskDetails(let task):
+            return BuildTaskFeature.makeFeature(dependencies, task: task)
+        case .monitorLive:
+            return MonitorLiveFeature.makeFeature(dependencies)
+        case .monitorActiveBuilds:
+            return MonitorActiveBuildsFeature.makeFeature(dependencies)
+        case .monitorActiveTasks:
+            return MonitorActiveTasksFeature.makeFeature(dependencies)
+        case .monitorQueues:
+            return MonitorQueuesFeature.makeFeature(dependencies)
+        case .historyTasks:
+            return HistoryTasksFeature.makeFeature(dependencies)
+        case .historyBuilds:
+            return HistoryBuildsFeature.makeFeature(dependencies)
+        case .settingsStampedeServer:
+            return SettingsStampedeServerFeature.makeFeature(dependencies)
+        case .settingsRepositories:
+            return SettingsRepositoriesFeature.makeFeature(dependencies)
+        case .settingsNotifications:
+            return SettingsNotificationsFeature.makeFeature(dependencies)
+        case .settingsInfo:
+            return SettingsInfoFeature.makeFeature(dependencies)
+        }
+    }
+}

--- a/Stampede/Stampede/Common/Router.swift
+++ b/Stampede/Stampede/Common/Router.swift
@@ -1,0 +1,40 @@
+//
+//  Router.swift
+//  Stampede
+//
+//  Created by David House on 10/11/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+protocol RouterDelegate: class {
+    func shouldRoute(to: Route) -> Bool
+    func routeMethod(for: Route) -> RouteMethod
+    func push(route: Route)
+    func present(route: Route)
+}
+
+class Router: ObservableObject {
+
+    weak var delegate: RouterDelegate?
+
+    init(delegate: RouterDelegate? = nil) {
+        self.delegate = delegate
+    }
+
+    func route(to route: Route) {
+        guard let delegate = delegate, delegate.shouldRoute(to: route) else {
+            return
+        }
+
+        let method = delegate.routeMethod(for: route)
+        switch method {
+        case .present:
+            delegate.present(route: route)
+        case .push:
+            delegate.push(route: route)
+        }
+    }
+}

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
@@ -27,62 +27,90 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     var configOverrides = ConfigOverrides.someOverrides
     var configQueues = Queue.someQueues
     var buildKeys = BuildKey.someBranchKeys
-    
+
+    var fetchRepositoriesPublisherCalled = false
+    var fetchActiveBuildsPublisherCalled = false
+    var fetchRepositoryBuildsPublisherCalled = false
+    var fetchMonitorQueuesPublisherCalled = false
+    var fetchWorkerStatusPublisherCalled = false
+    var fetchActiveTasksPublisherCalled = false
+    var fetchHistoryTasksPublisherCalled = false
+    var fetchHistoryHourlySummaryPublisherCalled = false
+    var fetchAdminTasksPublisherCalled = false
+    var fetchAdminConfigDefaultsPublisherCalled = false
+    var fetchAdminConfigOverridesPublisherCalled = false
+    var fetchAdminQueuesPublisherCalled = false
+    var fetchBuildKeysPublisherCalled = false
+
     var hostPassthroughSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
     
     func fetchRepositoriesPublisher() -> AnyPublisher<[Repository], ServiceError>? {
+        fetchRepositoriesPublisherCalled = true
         return fetchPublisher(repositories)
     }
     
     func fetchActiveBuildsPublisher(owner: String, repository: String) -> AnyPublisher<[BuildStatus], ServiceError>? {
+        fetchActiveBuildsPublisherCalled = true
         return fetchPublisher(repositoryActiveBuilds)
     }
     
     func fetchRepositoryBuildsPublisher(owner: String, repository: String) -> AnyPublisher<[RepositoryBuild], ServiceError>? {
+        fetchRepositoryBuildsPublisherCalled = true
         return fetchPublisher(repositoryBuilds)
     }
     
     func fetchActiveBuildsPublisher() -> AnyPublisher<[BuildStatus], ServiceError>? {
+        fetchActiveBuildsPublisherCalled = true
         return fetchPublisher(activeBuilds)
     }
     
     func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>? {
+        fetchMonitorQueuesPublisherCalled = true
         return fetchPublisher(queues)
     }
     
     func fetchWorkerStatusPublisher() -> AnyPublisher<[WorkerStatus], ServiceError>? {
+        fetchWorkerStatusPublisherCalled = true
         return fetchPublisher(workerStatus)
     }
     
     func fetchActiveTasksPublisher() -> AnyPublisher<[TaskStatus], ServiceError>? {
+        fetchActiveTasksPublisherCalled = true
         return fetchPublisher(activeTasks)
     }
-    
+
     func fetchHistoryTasksPublisher() -> AnyPublisher<[TaskStatus], ServiceError>? {
+        fetchHistoryTasksPublisherCalled = true
         return fetchPublisher(historyTasks)
     }
     
     func fetchHistoryHourlySummaryPublisher() -> AnyPublisher<[HourlySummary], ServiceError>? {
+        fetchHistoryHourlySummaryPublisherCalled = true
         return fetchPublisher(hourlySummary)
     }
     
     func fetchAdminTasksPublisher() -> AnyPublisher<[Task], ServiceError>? {
+        fetchAdminTasksPublisherCalled = true
         return fetchPublisher(tasks)
     }
     
     func fetchAdminConfigDefaultsPublisher() -> AnyPublisher<ConfigDefaults, ServiceError>? {
+        fetchAdminConfigDefaultsPublisherCalled = true
         return fetchPublisher(configDefaults)
     }
     
     func fetchAdminConfigOverridesPublisher() -> AnyPublisher<ConfigOverrides, ServiceError>? {
+        fetchAdminConfigOverridesPublisherCalled = true
         return fetchPublisher(configOverrides)
     }
     
     func fetchAdminQueuesPublisher() -> AnyPublisher<[Queue], ServiceError>? {
+        fetchAdminQueuesPublisherCalled = true
         return fetchPublisher(configQueues)
     }
 
     func fetchBuildKeysPublisher(owner: String, repository: String, source: String) -> AnyPublisher<[BuildKey], ServiceError>? {
+        fetchBuildKeysPublisherCalled = true
         return fetchPublisher(buildKeys)
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildFeature.swift
@@ -8,26 +8,42 @@
 
 import SwiftUI
 
-struct BuildFeature: View {
+class BuildFeature: BaseFeature {
 
-    // MARK: - Properties
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies, build: BuildStatus) -> BaseFeature {
+        return BuildFeature(dependencies: dependencies, buildStatus: build)
+    }
+    
+    // MARK: - Private Properties
+    
+    private var viewModel: BuildViewModel
 
-    let buildStatus: BuildStatus
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    BuildView(viewModel: viewModel, router: self)
+                                    .dependenciesToEnvironment(dependencies))
+    }
 
-    // MARK: - View
-
-    var body: some View {
-        BuildView(viewModel: BuildViewModel(buildStatus: buildStatus))
-            .navigationBarTitle(buildStatus.buildIdentifier)
+    // MARK: - Initializer
+    
+    init(dependencies: Dependencies, buildStatus: BuildStatus) {
+        viewModel = BuildViewModel(buildStatus: buildStatus)
+        super.init(dependencies: dependencies)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = viewModel.buildStatus.buildIdentifier
+        navigationItem.largeTitleDisplayMode = .automatic
     }
 }
-
-#if DEBUG
-struct BuildFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            BuildFeature(buildStatus: BuildStatus.someActiveBuild)
-        }
-    }
-}
-#endif

--- a/Stampede/Stampede/Features/Build/BuildFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildFeature.swift
@@ -24,7 +24,9 @@ class BuildFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    BuildView(viewModel: viewModel, router: self)
+                                    BuildView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
@@ -5,25 +5,45 @@
 //  Created by David House on 12/2/19.
 //  Copyright © 2019 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct BuildTaskFeature: View {
+class BuildTaskFeature: BaseFeature {
+    
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies, task: TaskStatus) -> BaseFeature {
+        return BuildTaskFeature(dependencies: dependencies, task: task)
+    }
+    
+    // MARK: - Private Properties
+    
+    private var viewModel: BuildTaskViewModel
 
-    let task: TaskStatus
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    BuildTaskView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
+    }
 
-    var body: some View {
-        BuildTaskView(viewModel: BuildTaskViewModel(task: task))
-            .navigationBarTitle(task.task)
+    // MARK: - Initializer
+    
+    init(dependencies: Dependencies, task: TaskStatus) {
+        viewModel = BuildTaskViewModel(task: task)
+        super.init(dependencies: dependencies)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = viewModel.task.task
+        navigationItem.largeTitleDisplayMode = .automatic
     }
 }
-
-#if DEBUG
-struct BuildTaskFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            BuildTaskFeature(task: TaskStatus.completedTask)
-        }
-    }
-}
-#endif

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
@@ -24,7 +24,9 @@ class BuildTaskFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    BuildTaskView(viewModel: viewModel)
+                                    BuildTaskView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct BuildTaskView: View {
 
-    @ObservedObject var viewModel: BuildTaskViewModel
+    @EnvironmentObject var viewModel: BuildTaskViewModel
 
     var body: some View {
         List {
@@ -62,7 +62,7 @@ struct BuildTaskView: View {
 struct BuildTaskView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            BuildTaskView(viewModel: BuildTaskViewModel(task: TaskStatus.completedTask))
+            BuildTaskView().environmentObject(BuildTaskViewModel(task: TaskStatus.completedTask))
         }
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildView.swift
+++ b/Stampede/Stampede/Features/Build/BuildView.swift
@@ -10,20 +10,11 @@ import SwiftUI
 
 struct BuildView: View {
 
-    // MARK: - Properties
-    
-    let router: Router?
-
     // MARK: - Observed Objects
 
-    @ObservedObject var viewModel: BuildViewModel
+    @EnvironmentObject var viewModel: BuildViewModel
+    @EnvironmentObject var router: Router
 
-    // Initializer
-    init(viewModel: BuildViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
-    
     // MARK: - View
 
     var body: some View {
@@ -71,7 +62,7 @@ struct BuildView: View {
                 Section(header: Text("Tasks")) {
                     ForEach(viewModel.buildStatus.tasks) { task in
                         Button(action: {
-                            router?.route(to: .taskDetails(task))
+                            router.route(to: .taskDetails(task))
                         }, label: {
                             TaskStatusCell(taskStatus: task)
                         })
@@ -85,8 +76,8 @@ struct BuildView: View {
 struct BuildView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            BuildView(viewModel: BuildViewModel(buildStatus: BuildStatus.someActiveBuild))
-            BuildView(viewModel: BuildViewModel(buildStatus: BuildStatus.someRecentSuccessBuild))
+            BuildView().environmentObject(BuildViewModel(buildStatus: BuildStatus.someActiveBuild))
+            BuildView().environmentObject(BuildViewModel(buildStatus: BuildStatus.someRecentSuccessBuild))
         }
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildView.swift
+++ b/Stampede/Stampede/Features/Build/BuildView.swift
@@ -10,12 +10,20 @@ import SwiftUI
 
 struct BuildView: View {
 
-    // MARK: - Environment
+    // MARK: - Properties
+    
+    let router: Router?
 
     // MARK: - Observed Objects
 
     @ObservedObject var viewModel: BuildViewModel
 
+    // Initializer
+    init(viewModel: BuildViewModel, router: Router? = nil) {
+        self.viewModel = viewModel
+        self.router = router
+    }
+    
     // MARK: - View
 
     var body: some View {
@@ -62,9 +70,11 @@ struct BuildView: View {
 
                 Section(header: Text("Tasks")) {
                     ForEach(viewModel.buildStatus.tasks) { task in
-                        NavigationLink(destination: BuildTaskFeature(task: task)) {
+                        Button(action: {
+                            router?.route(to: .taskDetails(task))
+                        }, label: {
                             TaskStatusCell(taskStatus: task)
-                        }
+                        })
                     }
                 }
         }

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
@@ -5,33 +5,31 @@
 //  Created by David House on 7/11/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct HistoryBuildsFeature: View {
+class HistoryBuildsFeature: BaseFeature<Dependencies> {
     
-    @EnvironmentObject var service: StampedeService
+    // MARK: - Private Properties
     
-    let viewModel: HistoryBuildsViewModel
+    private var viewModel = HistoryBuildsViewModel(state: .loading)
 
-    init(viewModel: HistoryBuildsViewModel? = nil) {
-        self.viewModel = viewModel ?? HistoryBuildsViewModel()
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    HistoryBuildsView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
     }
     
-    var body: some View {
-        HistoryBuildsView(viewModel: viewModel)
-            .navigationBarTitle("Build History")
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Build History"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
     }
 }
-
-#if DEBUG
-struct HistoryBuildsFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                HistoryBuildsFeature()
-            }
-        }
-    }
-}
-#endif

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
@@ -8,8 +8,14 @@
 import UIKit
 import SwiftUI
 
-class HistoryBuildsFeature: BaseFeature<Dependencies> {
+class HistoryBuildsFeature: BaseFeature {
     
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return HistoryBuildsFeature(dependencies: dependencies)
+    }
+
     // MARK: - Private Properties
     
     private var viewModel = HistoryBuildsViewModel(state: .loading)
@@ -18,7 +24,7 @@ class HistoryBuildsFeature: BaseFeature<Dependencies> {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    HistoryBuildsView(viewModel: viewModel)
+                                    HistoryBuildsView(viewModel: viewModel, router: self)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
@@ -24,7 +24,9 @@ class HistoryBuildsFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    HistoryBuildsView(viewModel: viewModel, router: self)
+                                    HistoryBuildsView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
@@ -9,21 +9,11 @@
 import SwiftUI
 
 struct HistoryBuildsView: View {
-    
-    // MARK: - Private Properties
-    
-    private let router: Router?
-    
+
     // MARK: - View Model
     
-    @ObservedObject var viewModel: HistoryBuildsViewModel
-
-    // MARK: - Initializer
-    
-    init(viewModel: HistoryBuildsViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
+    @EnvironmentObject var viewModel: HistoryBuildsViewModel
+    @EnvironmentObject var router: Router
 
     // MARK: - Body
     
@@ -45,7 +35,7 @@ struct HistoryBuildsView: View {
             List {
                 ForEach(activeBuilds, id: \.self) { item in
                     Button(action: {
-                        router?.route(to: .buildDetails(item))
+                        router.route(to: .buildDetails(item))
                     }, label: {
                         BuildStatusCell(buildStatus: item)
                     })
@@ -60,9 +50,9 @@ struct HistoryBuildsView: View {
 struct HistoryBuildsView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            HistoryBuildsView(viewModel: HistoryBuildsViewModel.loading)
-            HistoryBuildsView(viewModel: HistoryBuildsViewModel.networkError)
-            HistoryBuildsView(viewModel: HistoryBuildsViewModel.someBuilds)
+            HistoryBuildsView().environmentObject(HistoryBuildsViewModel.loading)
+            HistoryBuildsView().environmentObject(HistoryBuildsViewModel.networkError)
+            HistoryBuildsView().environmentObject(HistoryBuildsViewModel.someBuilds)
         }
     }
 }

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
@@ -10,14 +10,19 @@ import SwiftUI
 
 struct HistoryBuildsView: View {
     
+    // MARK: - Private Properties
+    
+    private let router: Router?
+    
     // MARK: - View Model
     
     @ObservedObject var viewModel: HistoryBuildsViewModel
 
     // MARK: - Initializer
     
-    init(viewModel: HistoryBuildsViewModel) {
+    init(viewModel: HistoryBuildsViewModel, router: Router? = nil) {
         self.viewModel = viewModel
+        self.router = router
     }
 
     // MARK: - Body
@@ -39,9 +44,11 @@ struct HistoryBuildsView: View {
         case .results(let activeBuilds):
             List {
                 ForEach(activeBuilds, id: \.self) { item in
-                    NavigationLink(destination: BuildFeature(buildStatus: item)) {
+                    Button(action: {
+                        router?.route(to: .buildDetails(item))
+                    }, label: {
                         BuildStatusCell(buildStatus: item)
-                    }
+                    })
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
@@ -10,12 +10,17 @@ import SwiftUI
 
 struct HistoryBuildsView: View {
     
+    // MARK: - View Model
+    
     @ObservedObject var viewModel: HistoryBuildsViewModel
 
-    init(viewModel: HistoryBuildsViewModel, publisher: BuildStatusResponsePublisher? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: HistoryBuildsViewModel) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
     }
+
+    // MARK: - Body
     
     var body: some View {
         switch viewModel.state {
@@ -35,8 +40,7 @@ struct HistoryBuildsView: View {
             List {
                 ForEach(activeBuilds, id: \.self) { item in
                     NavigationLink(destination: BuildFeature(buildStatus: item)) {
-                        Text("test")
-                        //BuildStatusCell(buildStatus: item)
+                        BuildStatusCell(buildStatus: item)
                     }
                 }
             }

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
@@ -34,11 +34,7 @@ struct HistoryBuildsView: View {
         case .results(let activeBuilds):
             List {
                 ForEach(activeBuilds, id: \.self) { item in
-                    Button(action: {
-                        router.route(to: .buildDetails(item))
-                    }, label: {
-                        BuildStatusCell(buildStatus: item)
-                    })
+                    BuildStatusCell(buildStatus: item)
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
@@ -8,7 +8,13 @@
 import UIKit
 import SwiftUI
 
-class HistoryTasksFeature: BaseFeature<Dependencies> {
+class HistoryTasksFeature: BaseFeature {
+    
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return HistoryTasksFeature(dependencies: dependencies)
+    }
     
     // MARK: - Private Properties
     
@@ -18,7 +24,7 @@ class HistoryTasksFeature: BaseFeature<Dependencies> {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    HistoryTasksView(viewModel: viewModel)
+                                    HistoryTasksView(viewModel: viewModel, router: self)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
@@ -5,33 +5,32 @@
 //  Created by David House on 7/11/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct HistoryTasksFeature: View {
+class HistoryTasksFeature: BaseFeature<Dependencies> {
     
-    @EnvironmentObject var service: StampedeService
+    // MARK: - Private Properties
     
-    let viewModel: HistoryTasksViewModel
+    private var viewModel = HistoryTasksViewModel(state: .loading)
 
-    init(viewModel: HistoryTasksViewModel? = nil) {
-        self.viewModel = viewModel ?? HistoryTasksViewModel()
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    HistoryTasksView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
     }
     
-    var body: some View {
-        HistoryTasksView(viewModel: viewModel, publisher: service.fetchHistoryTasksPublisher())
-            .navigationBarTitle("Task History")
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Task History"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.publisher = dependencies.service.fetchHistoryTasksPublisher()
     }
 }
-
-#if DEBUG
-struct HistoryTasksFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                HistoryTasksFeature()
-            }
-        }
-    }
-}
-#endif

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
@@ -24,7 +24,9 @@ class HistoryTasksFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    HistoryTasksView(viewModel: viewModel, router: self)
+                                    HistoryTasksView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -10,20 +10,10 @@ import SwiftUI
 
 struct HistoryTasksView: View {
 
-    // MARK: - Private properties
-    
-    private let router: Router?
-    
     // MARK: - View Model
     
-    @ObservedObject var viewModel: HistoryTasksViewModel
-
-    // MARK: - Initializer
-    
-    init(viewModel: HistoryTasksViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
+    @EnvironmentObject var viewModel: HistoryTasksViewModel
+    @EnvironmentObject var router: Router
 
     // MARK: - Body
     
@@ -47,7 +37,7 @@ struct HistoryTasksView: View {
             List {
                 ForEach(tasks, id: \.self) { item in
                     Button(action: {
-                        router?.route(to: .taskDetails(item))
+                        router.route(to: .taskDetails(item))
                     }, label: {
                         TaskStatusCell(taskStatus: item)
                     })
@@ -62,9 +52,9 @@ struct HistoryTasksView: View {
 struct HistoryTasksView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            HistoryTasksView(viewModel: HistoryTasksViewModel.loading)
-            HistoryTasksView(viewModel: HistoryTasksViewModel.networkError)
-            HistoryTasksView(viewModel: HistoryTasksViewModel.someTasks)
+            HistoryTasksView().environmentObject(HistoryTasksViewModel.loading)
+            HistoryTasksView().environmentObject(HistoryTasksViewModel.networkError)
+            HistoryTasksView().environmentObject(HistoryTasksViewModel.someTasks)
         }
     }
 }

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -10,14 +10,19 @@ import SwiftUI
 
 struct HistoryTasksView: View {
 
+    // MARK: - Private properties
+    
+    private let router: Router?
+    
     // MARK: - View Model
     
     @ObservedObject var viewModel: HistoryTasksViewModel
 
     // MARK: - Initializer
     
-    init(viewModel: HistoryTasksViewModel) {
+    init(viewModel: HistoryTasksViewModel, router: Router? = nil) {
         self.viewModel = viewModel
+        self.router = router
     }
 
     // MARK: - Body
@@ -41,9 +46,11 @@ struct HistoryTasksView: View {
         case .results(let tasks):
             List {
                 ForEach(tasks, id: \.self) { item in
-                    NavigationLink(destination: BuildTaskFeature(task: item)) {
+                    Button(action: {
+                        router?.route(to: .taskDetails(item))
+                    }, label: {
                         TaskStatusCell(taskStatus: item)
-                    }
+                    })
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -10,12 +10,17 @@ import SwiftUI
 
 struct HistoryTasksView: View {
 
+    // MARK: - View Model
+    
     @ObservedObject var viewModel: HistoryTasksViewModel
 
-    init(viewModel: HistoryTasksViewModel, publisher: TaskStatusResponsePublisher? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: HistoryTasksViewModel) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
     }
+
+    // MARK: - Body
     
     var body: some View {
         switch viewModel.state {

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -12,9 +12,7 @@ import HouseKit
 
 class MainFeature: BaseFeature<Dependencies> {
 
-    var viewModel = MainViewModel()
-    var publisher: AnyPublisher<[Repository], ServiceError>?
-    private var disposables = Set<AnyCancellable>()
+    var viewModel = MainViewModel(state: .loading)
 
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
@@ -29,19 +27,21 @@ class MainFeature: BaseFeature<Dependencies> {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
-        self.publisher?.sink(receiveCompletion: { result in
-          if case let .failure(error) = result {
-            print("Error receiving \(error)")
-            DispatchQueue.main.async {
-                self.viewModel.repositories = []
-            }
-          }
-        }, receiveValue: { value in
-            DispatchQueue.main.async {
-                self.viewModel.repositories = value
-            }
-        }).store(in: &self.disposables)
+        viewModel.publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
+//
+//        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
+//        self.publisher?.sink(receiveCompletion: { result in
+//          if case let .failure(error) = result {
+//            print("Error receiving \(error)")
+//            DispatchQueue.main.async {
+//                self.viewModel.repositories = []
+//            }
+//          }
+//        }, receiveValue: { value in
+//            DispatchQueue.main.async {
+//                self.viewModel.repositories = value
+//            }
+//        }).store(in: &self.disposables)
     }
 
 //    @EnvironmentObject var repositoryList: RepositoryList

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -18,19 +18,18 @@ class MainFeature: BaseFeature<Dependencies> {
 
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MainView(viewModel: viewModel)
+                                    MainView(viewModel: viewModel, delegate: self)
                                     .dependenciesToEnvironment(dependencies))
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
-
         title = "Stampede"
         navigationItem.largeTitleDisplayMode = .automatic
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
         self.publisher?.sink(receiveCompletion: { result in
           if case let .failure(error) = result {
             print("Error receiving \(error)")
@@ -61,6 +60,14 @@ class MainFeature: BaseFeature<Dependencies> {
 //            .navigationTitle("Stampede")
 //        }
 //    }
+}
+
+extension MainFeature: MainViewDelegate {
+    
+    func didSelectSettingsRepositories() {
+        let settingsRepositoriesFeature = SettingsRepositoriesFeature(dependencies: dependencies)
+        navigationController?.pushViewController(settingsRepositoriesFeature, animated: true)
+    }
 }
 
 //#if DEBUG

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -44,39 +44,48 @@ extension MainFeature: MainViewDelegate {
     }
 
     func didSelectMonitorLive() {
-        
+        let monitorLiveFeature = MonitorLiveFeature(dependencies: dependencies)
+        navigationController?.pushViewController(monitorLiveFeature, animated: true)
     }
 
     func didSelectMonitorActiveBuilds() {
-        
+        let monitorActiveBuilds = MonitorActiveBuildsFeature(dependencies: dependencies)
+        navigationController?.pushViewController(monitorActiveBuilds, animated: true)
     }
 
     func didSelectMonitorActiveTasks() {
-        
+        let monitorActiveTasks = MonitorActiveTasksFeature(dependencies: dependencies)
+        navigationController?.pushViewController(monitorActiveTasks, animated: true)
     }
 
     func didSelectMonitorQueues() {
-        
+        let monitorQueues = MonitorQueuesFeature(dependencies: dependencies)
+        navigationController?.pushViewController(monitorQueues, animated: true)
     }
 
     func didSelectHistoryBuilds() {
-        
+        let historyBuilds = HistoryBuildsFeature(dependencies: dependencies)
+        navigationController?.pushViewController(historyBuilds, animated: true)
     }
 
     func didSelectHistoryTasks() {
-        
+        let historyTasks = HistoryTasksFeature(dependencies: dependencies)
+        navigationController?.pushViewController(historyTasks, animated: true)
     }
 
     func didSelectSettingsStampedeServer() {
-        
+        let stampedeServer = SettingsStampedeServerFeature(dependencies: dependencies)
+        navigationController?.pushViewController(stampedeServer, animated: true)
     }
 
     func didSelectSettingsNotifications() {
-        
+        let notifications = SettingsNotificationsFeature(dependencies: dependencies)
+        navigationController?.pushViewController(notifications, animated: true)
     }
 
     func didSelectSettingsInfo() {
-        
+        let info = SettingsInfoFeature(dependencies: dependencies)
+        navigationController?.pushViewController(info, animated: true)
     }
 
     func didSelectSettingsRepositories() {

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Combine
 import HouseKit
 
-class MainFeature: BaseFeature<Dependencies> {
+class MainFeature: BaseFeature {
 
     // MARK: - Private Properties
     
@@ -20,7 +20,7 @@ class MainFeature: BaseFeature<Dependencies> {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MainView(viewModel: viewModel, delegate: self)
+                                    MainView(viewModel: viewModel, router: self)
                                     .dependenciesToEnvironment(dependencies))
     }
 
@@ -34,62 +34,5 @@ class MainFeature: BaseFeature<Dependencies> {
 
     override func viewDidAppear(_ animated: Bool) {
         viewModel.publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
-    }
-}
-
-extension MainFeature: MainViewDelegate {
-    
-    func didSelectRepository(_ repository: Repository) {
-        
-    }
-
-    func didSelectMonitorLive() {
-        let monitorLiveFeature = MonitorLiveFeature(dependencies: dependencies)
-        navigationController?.pushViewController(monitorLiveFeature, animated: true)
-    }
-
-    func didSelectMonitorActiveBuilds() {
-        let monitorActiveBuilds = MonitorActiveBuildsFeature(dependencies: dependencies)
-        navigationController?.pushViewController(monitorActiveBuilds, animated: true)
-    }
-
-    func didSelectMonitorActiveTasks() {
-        let monitorActiveTasks = MonitorActiveTasksFeature(dependencies: dependencies)
-        navigationController?.pushViewController(monitorActiveTasks, animated: true)
-    }
-
-    func didSelectMonitorQueues() {
-        let monitorQueues = MonitorQueuesFeature(dependencies: dependencies)
-        navigationController?.pushViewController(monitorQueues, animated: true)
-    }
-
-    func didSelectHistoryBuilds() {
-        let historyBuilds = HistoryBuildsFeature(dependencies: dependencies)
-        navigationController?.pushViewController(historyBuilds, animated: true)
-    }
-
-    func didSelectHistoryTasks() {
-        let historyTasks = HistoryTasksFeature(dependencies: dependencies)
-        navigationController?.pushViewController(historyTasks, animated: true)
-    }
-
-    func didSelectSettingsStampedeServer() {
-        let stampedeServer = SettingsStampedeServerFeature(dependencies: dependencies)
-        navigationController?.pushViewController(stampedeServer, animated: true)
-    }
-
-    func didSelectSettingsNotifications() {
-        let notifications = SettingsNotificationsFeature(dependencies: dependencies)
-        navigationController?.pushViewController(notifications, animated: true)
-    }
-
-    func didSelectSettingsInfo() {
-        let info = SettingsInfoFeature(dependencies: dependencies)
-        navigationController?.pushViewController(info, animated: true)
-    }
-
-    func didSelectSettingsRepositories() {
-        let settingsRepositoriesFeature = SettingsRepositoriesFeature(dependencies: dependencies)
-        navigationController?.pushViewController(settingsRepositoriesFeature, animated: true)
     }
 }

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -5,35 +5,70 @@
 //  Created by David House on 12/1/19.
 //  Copyright © 2019 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
+import Combine
+import HouseKit
 
-struct MainFeature: View {
+class MainFeature: BaseFeature<Dependencies> {
 
-    @EnvironmentObject var repositoryList: RepositoryList
-    
-    let viewModel: MainViewModel
+    var viewModel = MainViewModel()
+    var publisher: AnyPublisher<[Repository], ServiceError>?
+    private var disposables = Set<AnyCancellable>()
 
-    init(viewModel: MainViewModel? = nil) {
-        self.viewModel = viewModel ?? MainViewModel()
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    MainView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
     }
-    
-    // MARK: - View
 
-    var body: some View {
-        NavigationView {
-            MainView(viewModel: viewModel, publisher: repositoryList.fetchRepositoriesPublisher())
-            .navigationTitle("Stampede")
-        }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
+
+        title = "Stampede"
+        navigationItem.largeTitleDisplayMode = .automatic
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        self.publisher?.sink(receiveCompletion: { result in
+          if case let .failure(error) = result {
+            print("Error receiving \(error)")
+            DispatchQueue.main.async {
+                self.viewModel.repositories = []
+            }
+          }
+        }, receiveValue: { value in
+            DispatchQueue.main.async {
+                self.viewModel.repositories = value
+            }
+        }).store(in: &self.disposables)
+    }
+
+//    @EnvironmentObject var repositoryList: RepositoryList
+//
+//    let viewModel: MainViewModel
+//
+//    init(viewModel: MainViewModel? = nil) {
+//        self.viewModel = viewModel ?? MainViewModel()
+//    }
+//
+//    // MARK: - View
+//
+//    var body: some View {
+//        NavigationView {
+//            MainView(viewModel: viewModel, publisher: repositoryList.fetchRepositoriesPublisher())
+//            .navigationTitle("Stampede")
+//        }
+//    }
 }
 
-#if DEBUG
-struct MainFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            MainFeature()
-        }
-    }
-}
-#endif
+//#if DEBUG
+//struct MainFeature_Previews: PreviewProvider {
+//    static var previews: some View {
+//        DevicePreviewer {
+//            MainFeature()
+//        }
+//    }
+//}
+//#endif

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -12,14 +12,20 @@ import HouseKit
 
 class MainFeature: BaseFeature<Dependencies> {
 
-    var viewModel = MainViewModel(state: .loading)
+    // MARK: - Private Properties
+    
+    private var viewModel = MainViewModel(state: .loading)
 
+    // MARK: - Overrides
+    
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
                                     MainView(viewModel: viewModel, delegate: self)
                                     .dependenciesToEnvironment(dependencies))
     }
 
+    // MARK: - View Lifecycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Stampede"
@@ -28,54 +34,53 @@ class MainFeature: BaseFeature<Dependencies> {
 
     override func viewDidAppear(_ animated: Bool) {
         viewModel.publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
-//
-//        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
-//        self.publisher?.sink(receiveCompletion: { result in
-//          if case let .failure(error) = result {
-//            print("Error receiving \(error)")
-//            DispatchQueue.main.async {
-//                self.viewModel.repositories = []
-//            }
-//          }
-//        }, receiveValue: { value in
-//            DispatchQueue.main.async {
-//                self.viewModel.repositories = value
-//            }
-//        }).store(in: &self.disposables)
     }
-
-//    @EnvironmentObject var repositoryList: RepositoryList
-//
-//    let viewModel: MainViewModel
-//
-//    init(viewModel: MainViewModel? = nil) {
-//        self.viewModel = viewModel ?? MainViewModel()
-//    }
-//
-//    // MARK: - View
-//
-//    var body: some View {
-//        NavigationView {
-//            MainView(viewModel: viewModel, publisher: repositoryList.fetchRepositoriesPublisher())
-//            .navigationTitle("Stampede")
-//        }
-//    }
 }
 
 extension MainFeature: MainViewDelegate {
     
+    func didSelectRepository(_ repository: Repository) {
+        
+    }
+
+    func didSelectMonitorLive() {
+        
+    }
+
+    func didSelectMonitorActiveBuilds() {
+        
+    }
+
+    func didSelectMonitorActiveTasks() {
+        
+    }
+
+    func didSelectMonitorQueues() {
+        
+    }
+
+    func didSelectHistoryBuilds() {
+        
+    }
+
+    func didSelectHistoryTasks() {
+        
+    }
+
+    func didSelectSettingsStampedeServer() {
+        
+    }
+
+    func didSelectSettingsNotifications() {
+        
+    }
+
+    func didSelectSettingsInfo() {
+        
+    }
+
     func didSelectSettingsRepositories() {
         let settingsRepositoriesFeature = SettingsRepositoriesFeature(dependencies: dependencies)
         navigationController?.pushViewController(settingsRepositoriesFeature, animated: true)
     }
 }
-
-//#if DEBUG
-//struct MainFeature_Previews: PreviewProvider {
-//    static var previews: some View {
-//        DevicePreviewer {
-//            MainFeature()
-//        }
-//    }
-//}
-//#endif

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -20,7 +20,9 @@ class MainFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MainView(viewModel: viewModel, router: self)
+                                    MainView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Main/MainNavigationController.swift
+++ b/Stampede/Stampede/Features/Main/MainNavigationController.swift
@@ -9,6 +9,4 @@
 import Foundation
 import UIKit
 
-class MainNavigationController: UINavigationController {
-    
-}
+class MainNavigationController: UINavigationController { }

--- a/Stampede/Stampede/Features/Main/MainNavigationController.swift
+++ b/Stampede/Stampede/Features/Main/MainNavigationController.swift
@@ -1,0 +1,14 @@
+//
+//  MainNavigationController.swift
+//  Stampede
+//
+//  Created by David House on 10/10/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class MainNavigationController: UINavigationController {
+    
+}

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -11,25 +11,14 @@ import HouseKit
 
 struct MainView: View {
 
-    // MARK: - View Model
-    
-    @ObservedObject var viewModel: MainViewModel
-
     // MARK: - Environment
 
     @EnvironmentObject var theme: CurrentTheme
-    
-    // MARK: - Private properties
-    
-    private let router: Router?
+    @EnvironmentObject var viewModel: MainViewModel
+    @EnvironmentObject var router: Router
 
-    // MARK: - Initializer
-    
-    init(viewModel: MainViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
-    
+    // MARK: - Private properties
+
     // MARK: - View
 
     var body: some View {
@@ -43,7 +32,7 @@ struct MainView: View {
                 case .results(let repositories):
                     ForEach(repositories, id: \.self) { item in
                         Button(action: {
-                            self.router?.route(to: .repositoryDetails(item))
+                            self.router.route(to: .repositoryDetails(item))
                         }, label: {
                             RepositoryCell(repository: item)
                         }).accessibilityIdentifier(item.id)
@@ -52,46 +41,46 @@ struct MainView: View {
             }
             Section(header: Text("Monitor")) {
                 Button("Live", action: {
-                    router?.route(to: .monitorLive)
+                    router.route(to: .monitorLive)
                 })
                     .accessibility(identifier: "monitor-live")
                 Button("Active Builds", action: {
-                    router?.route(to: .monitorActiveBuilds)
+                    router.route(to: .monitorActiveBuilds)
                 })
                     .accessibility(identifier: "monitor-active-builds")
                 Button("Active Tasks", action: {
-                    router?.route(to: .monitorActiveTasks)
+                    router.route(to: .monitorActiveTasks)
                 })
                     .accessibility(identifier: "monitor-active-tasks")
                 Button("Queues", action: {
-                    router?.route(to: .monitorActiveTasks)
+                    router.route(to: .monitorActiveTasks)
                 })
                     .accessibility(identifier: "monitor-queues")
             }
             Section(header: Text("History")) {
                 Button("Builds", action: {
-                    router?.route(to: .historyBuilds)
+                    router.route(to: .historyBuilds)
                 })
                     .accessibility(identifier: "history-builds")
                 Button("Tasks", action: {
-                    router?.route(to: .historyTasks)
+                    router.route(to: .historyTasks)
                 })
                     .accessibility(identifier: "history-tasks")
             }
             Section(header: Text("Settings")) {
                 Button("Stampede Server", action: {
-                    router?.route(to: .settingsStampedeServer)
+                    router.route(to: .settingsStampedeServer)
                 })
                     .accessibility(identifier: "settings-stampede-server")
                 Button("Repositories", action: {
-                    router?.route(to: .settingsRepositories)
+                    router.route(to: .settingsRepositories)
                 })
                 .accessibility(identifier: "settings-repositories")
                 Button("Notifications", action: {
-                    router?.route(to: .settingsNotifications)
+                    router.route(to: .settingsNotifications)
                 }).accessibility(identifier: "settings-notifications")
                 Button("Info", action: {
-                    router?.route(to: .settingsInfo)
+                    router.route(to: .settingsInfo)
                 }).accessibility(identifier: "settings-info")
             }
         }.listStyle(GroupedListStyle())
@@ -103,7 +92,8 @@ struct MainView: View {
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {        
         Previewer {
-            MainView(viewModel: MainViewModel(state: .results(Repository.someRepositories)))
+            MainView()
+                .environmentObject(MainViewModel(state: .results(Repository.someRepositories)))
         }
     }
 }

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -40,48 +40,20 @@ struct MainView: View {
                 }
             }
             Section(header: Text("Monitor")) {
-                Button("Live", action: {
-                    router.route(to: .monitorLive)
-                })
-                    .accessibility(identifier: "monitor-live")
-                Button("Active Builds", action: {
-                    router.route(to: .monitorActiveBuilds)
-                })
-                    .accessibility(identifier: "monitor-active-builds")
-                Button("Active Tasks", action: {
-                    router.route(to: .monitorActiveTasks)
-                })
-                    .accessibility(identifier: "monitor-active-tasks")
-                Button("Queues", action: {
-                    router.route(to: .monitorActiveTasks)
-                })
-                    .accessibility(identifier: "monitor-queues")
+                FeatureRouteCell(title: "Live", route: .monitorLive)
+                FeatureRouteCell(title: "Active Builds", route: .monitorActiveBuilds)
+                FeatureRouteCell(title: "Active Tasks", route: .monitorActiveTasks)
+                FeatureRouteCell(title: "Queues", route: .monitorQueues)
             }
             Section(header: Text("History")) {
-                Button("Builds", action: {
-                    router.route(to: .historyBuilds)
-                })
-                    .accessibility(identifier: "history-builds")
-                Button("Tasks", action: {
-                    router.route(to: .historyTasks)
-                })
-                    .accessibility(identifier: "history-tasks")
+                FeatureRouteCell(title: "Builds", route: .historyBuilds)
+                FeatureRouteCell(title: "Tasks", route: .historyTasks)
             }
             Section(header: Text("Settings")) {
-                Button("Stampede Server", action: {
-                    router.route(to: .settingsStampedeServer)
-                })
-                    .accessibility(identifier: "settings-stampede-server")
-                Button("Repositories", action: {
-                    router.route(to: .settingsRepositories)
-                })
-                .accessibility(identifier: "settings-repositories")
-                Button("Notifications", action: {
-                    router.route(to: .settingsNotifications)
-                }).accessibility(identifier: "settings-notifications")
-                Button("Info", action: {
-                    router.route(to: .settingsInfo)
-                }).accessibility(identifier: "settings-info")
+                FeatureRouteCell(title: "Stampede Server", route: .settingsStampedeServer)
+                FeatureRouteCell(title: "Repositories", route: .settingsRepositories)
+                FeatureRouteCell(title: "Notifications", route: .settingsNotifications)
+                FeatureRouteCell(title: "Info", route: .settingsInfo)
             }
         }.listStyle(GroupedListStyle())
     }

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -9,13 +9,19 @@ import SwiftUI
 import Combine
 import HouseKit
 
+protocol MainViewDelegate: class {
+    func didSelectSettingsRepositories()
+}
+
 struct MainView: View {
 
     @ObservedObject var viewModel: MainViewModel
+    weak var delegate: MainViewDelegate?
 
-    init(viewModel: MainViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil) {
+    init(viewModel: MainViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, delegate: MainViewDelegate? = nil) {
         self.viewModel = viewModel
 //        self.viewModel.publisher = publisher
+        self.delegate = delegate
     }
     
     // MARK: - Environment
@@ -66,7 +72,9 @@ struct MainView: View {
             }
             Section(header: Text("Settings")) {
                 Button("Stampede Server", action: {})
-                Button("Repositories", action: {})
+                Button("Repositories", action: {
+                    delegate?.didSelectSettingsRepositories()
+                })
                 Button("Notifications", action: {})
                 Button("Info", action: {})
 //                NavigationLink(destination: SettingsStampedeServerFeature()) {

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -35,11 +35,17 @@ struct MainView: View {
     var body: some View {
         List {
             Section(header: Text("Repositories")) {
-                ForEach(viewModel.repositories, id: \.self) { item in
-//                        NavigationLink(destination: RepositoryFeature(repository: item)) {
+                switch viewModel.state {
+                case .loading:
+                    Text("Loading...")
+                case .networkError:
+                    Text("Network Error...")
+                case .results(let repositories):
+                    ForEach(repositories, id: \.self) { item in
                             RepositoryCell(repository: item)
                         .accessibilityIdentifier(item.id)
                     }
+                }
             }
             Section(header: Text("Monitor")) {
                 Button("Live", action: {})
@@ -95,10 +101,11 @@ struct MainView: View {
 }
 
 #if DEBUG
+
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {        
         Previewer {
-            MainView(viewModel: MainViewModel(repositories: Repository.someRepositories))
+            MainView(viewModel: MainViewModel(state: .results(Repository.someRepositories)))
         }
     }
 }

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -10,26 +10,47 @@ import Combine
 import HouseKit
 
 protocol MainViewDelegate: class {
+    // Favorite Repositories
+    func didSelectRepository(_ repository: Repository)
+    
+    // Monitor
+    func didSelectMonitorLive()
+    func didSelectMonitorActiveBuilds()
+    func didSelectMonitorActiveTasks()
+    func didSelectMonitorQueues()
+    
+    // History
+    func didSelectHistoryBuilds()
+    func didSelectHistoryTasks()
+    
+    // Settings
+    func didSelectSettingsStampedeServer()
     func didSelectSettingsRepositories()
+    func didSelectSettingsNotifications()
+    func didSelectSettingsInfo()
 }
 
 struct MainView: View {
 
-    @ObservedObject var viewModel: MainViewModel
-    weak var delegate: MainViewDelegate?
-
-    init(viewModel: MainViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, delegate: MainViewDelegate? = nil) {
-        self.viewModel = viewModel
-//        self.viewModel.publisher = publisher
-        self.delegate = delegate
-    }
+    // MARK: - View Model
     
+    @ObservedObject var viewModel: MainViewModel
+
     // MARK: - Environment
 
     @EnvironmentObject var theme: CurrentTheme
+    
+    // MARK: - Private properties
+    
+    private weak var delegate: MainViewDelegate?
 
-    // MARK: - Properties
-
+    // MARK: - Initializer
+    
+    init(viewModel: MainViewModel, delegate: MainViewDelegate? = nil) {
+        self.viewModel = viewModel
+        self.delegate = delegate
+    }
+    
     // MARK: - View
 
     var body: some View {
@@ -42,59 +63,57 @@ struct MainView: View {
                     Text("Network Error...")
                 case .results(let repositories):
                     ForEach(repositories, id: \.self) { item in
+                        Button(action: {
+                            self.delegate?.didSelectRepository(item)
+                        }) {
                             RepositoryCell(repository: item)
-                        .accessibilityIdentifier(item.id)
+                        }.accessibilityIdentifier(item.id)
                     }
                 }
             }
             Section(header: Text("Monitor")) {
-                Button("Live", action: {})
-                Button("Active Builds", action: {})
-                Button("Active Tasks", action: {})
-                Button("Queues", action: {})
-
-//                NavigationLink(destination: MonitorLiveFeature()) {
-//                    Text("Live")
-//                }.accessibility(identifier: "monitor-live")
-//                NavigationLink(destination: MonitorActiveBuildsFeature()) {
-//                    Text("Active Builds")
-//                }.accessibility(identifier: "monitor-active-builds")
-//                NavigationLink(destination: MonitorActiveTasksFeature()) {
-//                    Text("Active Tasks")
-//                }.accessibility(identifier: "monitor-active-tasks")
-//                NavigationLink(destination: MonitorQueuesFeature()) {
-//                    Text("Queues")
-//                }.accessibility(identifier: "monitor-queues")
+                Button("Live", action: {
+                    delegate?.didSelectMonitorLive()
+                })
+                    .accessibility(identifier: "monitor-live")
+                Button("Active Builds", action: {
+                    delegate?.didSelectMonitorActiveBuilds()
+                })
+                    .accessibility(identifier: "monitor-active-builds")
+                Button("Active Tasks", action: {
+                    delegate?.didSelectMonitorActiveTasks()
+                })
+                    .accessibility(identifier: "monitor-active-tasks")
+                Button("Queues", action: {
+                    delegate?.didSelectMonitorQueues()
+                })
+                    .accessibility(identifier: "monitor-queues")
             }
             Section(header: Text("History")) {
-                Button("Builds", action: {})
-                Button("Tasks", action: {})
-//                NavigationLink(destination: HistoryBuildsFeature()) {
-//                    Text("Builds")
-//                }.accessibility(identifier: "history-builds")
-//                NavigationLink(destination: HistoryTasksFeature()) {
-//                    Text("Tasks")
-//                }.accessibility(identifier: "history-tasks")
+                Button("Builds", action: {
+                    delegate?.didSelectHistoryBuilds()
+                })
+                    .accessibility(identifier: "history-builds")
+                Button("Tasks", action: {
+                    delegate?.didSelectHistoryTasks()
+                })
+                    .accessibility(identifier: "history-tasks")
             }
             Section(header: Text("Settings")) {
-                Button("Stampede Server", action: {})
+                Button("Stampede Server", action: {
+                    delegate?.didSelectSettingsStampedeServer()
+                })
+                    .accessibility(identifier: "settings-stampede-server")
                 Button("Repositories", action: {
                     delegate?.didSelectSettingsRepositories()
                 })
-                Button("Notifications", action: {})
-                Button("Info", action: {})
-//                NavigationLink(destination: SettingsStampedeServerFeature()) {
-//                    Text("Stampede Server")
-//                }.accessibility(identifier: "settings-stampede-server")
-//                NavigationLink(destination: SettingsRepositoriesFeature()) {
-//                    Text("Repositories")
-//                }.accessibility(identifier: "settings-repositories")
-//                NavigationLink(destination: SettingsNotificationsFeature()) {
-//                    Text("Notifications")
-//                }.accessibility(identifier: "settings-notifications")
-//                NavigationLink(destination: SettingsInfoFeature()) {
-//                    Text("Info")
-//                }.accessibility(identifier: "settings-info")
+                .accessibility(identifier: "settings-repositories")
+                Button("Notifications", action: {
+                    delegate?.didSelectSettingsNotifications()
+                }).accessibility(identifier: "settings-notifications")
+                Button("Info", action: {
+                    delegate?.didSelectSettingsInfo()
+                }).accessibility(identifier: "settings-info")
             }
         }.listStyle(GroupedListStyle())
     }

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -9,27 +9,6 @@ import SwiftUI
 import Combine
 import HouseKit
 
-protocol MainViewDelegate: class {
-    // Favorite Repositories
-    func didSelectRepository(_ repository: Repository)
-    
-    // Monitor
-    func didSelectMonitorLive()
-    func didSelectMonitorActiveBuilds()
-    func didSelectMonitorActiveTasks()
-    func didSelectMonitorQueues()
-    
-    // History
-    func didSelectHistoryBuilds()
-    func didSelectHistoryTasks()
-    
-    // Settings
-    func didSelectSettingsStampedeServer()
-    func didSelectSettingsRepositories()
-    func didSelectSettingsNotifications()
-    func didSelectSettingsInfo()
-}
-
 struct MainView: View {
 
     // MARK: - View Model
@@ -42,13 +21,13 @@ struct MainView: View {
     
     // MARK: - Private properties
     
-    private weak var delegate: MainViewDelegate?
+    private let router: Router?
 
     // MARK: - Initializer
     
-    init(viewModel: MainViewModel, delegate: MainViewDelegate? = nil) {
+    init(viewModel: MainViewModel, router: Router? = nil) {
         self.viewModel = viewModel
-        self.delegate = delegate
+        self.router = router
     }
     
     // MARK: - View
@@ -64,55 +43,55 @@ struct MainView: View {
                 case .results(let repositories):
                     ForEach(repositories, id: \.self) { item in
                         Button(action: {
-                            self.delegate?.didSelectRepository(item)
-                        }) {
+                            self.router?.route(to: .repositoryDetails(item))
+                        }, label: {
                             RepositoryCell(repository: item)
-                        }.accessibilityIdentifier(item.id)
+                        }).accessibilityIdentifier(item.id)
                     }
                 }
             }
             Section(header: Text("Monitor")) {
                 Button("Live", action: {
-                    delegate?.didSelectMonitorLive()
+                    router?.route(to: .monitorLive)
                 })
                     .accessibility(identifier: "monitor-live")
                 Button("Active Builds", action: {
-                    delegate?.didSelectMonitorActiveBuilds()
+                    router?.route(to: .monitorActiveBuilds)
                 })
                     .accessibility(identifier: "monitor-active-builds")
                 Button("Active Tasks", action: {
-                    delegate?.didSelectMonitorActiveTasks()
+                    router?.route(to: .monitorActiveTasks)
                 })
                     .accessibility(identifier: "monitor-active-tasks")
                 Button("Queues", action: {
-                    delegate?.didSelectMonitorQueues()
+                    router?.route(to: .monitorActiveTasks)
                 })
                     .accessibility(identifier: "monitor-queues")
             }
             Section(header: Text("History")) {
                 Button("Builds", action: {
-                    delegate?.didSelectHistoryBuilds()
+                    router?.route(to: .historyBuilds)
                 })
                     .accessibility(identifier: "history-builds")
                 Button("Tasks", action: {
-                    delegate?.didSelectHistoryTasks()
+                    router?.route(to: .historyTasks)
                 })
                     .accessibility(identifier: "history-tasks")
             }
             Section(header: Text("Settings")) {
                 Button("Stampede Server", action: {
-                    delegate?.didSelectSettingsStampedeServer()
+                    router?.route(to: .settingsStampedeServer)
                 })
                     .accessibility(identifier: "settings-stampede-server")
                 Button("Repositories", action: {
-                    delegate?.didSelectSettingsRepositories()
+                    router?.route(to: .settingsRepositories)
                 })
                 .accessibility(identifier: "settings-repositories")
                 Button("Notifications", action: {
-                    delegate?.didSelectSettingsNotifications()
+                    router?.route(to: .settingsNotifications)
                 }).accessibility(identifier: "settings-notifications")
                 Button("Info", action: {
-                    delegate?.didSelectSettingsInfo()
+                    router?.route(to: .settingsInfo)
                 }).accessibility(identifier: "settings-info")
             }
         }.listStyle(GroupedListStyle())

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -15,7 +15,7 @@ struct MainView: View {
 
     init(viewModel: MainViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
+//        self.viewModel.publisher = publisher
     }
     
     // MARK: - Environment
@@ -29,54 +29,60 @@ struct MainView: View {
     var body: some View {
         List {
             Section(header: Text("Repositories")) {
-                switch viewModel.state {
-                case .loading, .networkError:
-                    EmptyView()
-                case .results(let repositories):
-                    ForEach(repositories, id: \.self) { item in
-                        NavigationLink(destination: RepositoryFeature(repository: item)) {
+                ForEach(viewModel.repositories, id: \.self) { item in
+//                        NavigationLink(destination: RepositoryFeature(repository: item)) {
                             RepositoryCell(repository: item)
-                        }.accessibilityIdentifier(item.id)
+                        .accessibilityIdentifier(item.id)
                     }
-                }
             }
             Section(header: Text("Monitor")) {
-                NavigationLink(destination: MonitorLiveFeature()) {
-                    Text("Live")
-                }.accessibility(identifier: "monitor-live")
-                NavigationLink(destination: MonitorActiveBuildsFeature()) {
-                    Text("Active Builds")
-                }.accessibility(identifier: "monitor-active-builds")
-                NavigationLink(destination: MonitorActiveTasksFeature()) {
-                    Text("Active Tasks")
-                }.accessibility(identifier: "monitor-active-tasks")
-                NavigationLink(destination: MonitorQueuesFeature()) {
-                    Text("Queues")
-                }.accessibility(identifier: "monitor-queues")
+                Button("Live", action: {})
+                Button("Active Builds", action: {})
+                Button("Active Tasks", action: {})
+                Button("Queues", action: {})
+
+//                NavigationLink(destination: MonitorLiveFeature()) {
+//                    Text("Live")
+//                }.accessibility(identifier: "monitor-live")
+//                NavigationLink(destination: MonitorActiveBuildsFeature()) {
+//                    Text("Active Builds")
+//                }.accessibility(identifier: "monitor-active-builds")
+//                NavigationLink(destination: MonitorActiveTasksFeature()) {
+//                    Text("Active Tasks")
+//                }.accessibility(identifier: "monitor-active-tasks")
+//                NavigationLink(destination: MonitorQueuesFeature()) {
+//                    Text("Queues")
+//                }.accessibility(identifier: "monitor-queues")
             }
             Section(header: Text("History")) {
-                NavigationLink(destination: HistoryBuildsFeature()) {
-                    Text("Builds")
-                }.accessibility(identifier: "history-builds")
-                NavigationLink(destination: HistoryTasksFeature()) {
-                    Text("Tasks")
-                }.accessibility(identifier: "history-tasks")
+                Button("Builds", action: {})
+                Button("Tasks", action: {})
+//                NavigationLink(destination: HistoryBuildsFeature()) {
+//                    Text("Builds")
+//                }.accessibility(identifier: "history-builds")
+//                NavigationLink(destination: HistoryTasksFeature()) {
+//                    Text("Tasks")
+//                }.accessibility(identifier: "history-tasks")
             }
             Section(header: Text("Settings")) {
-                NavigationLink(destination: SettingsStampedeServerFeature()) {
-                    Text("Stampede Server")
-                }.accessibility(identifier: "settings-stampede-server")
-                NavigationLink(destination: SettingsRepositoriesFeature()) {
-                    Text("Repositories")
-                }.accessibility(identifier: "settings-repositories")
-                NavigationLink(destination: SettingsNotificationsFeature()) {
-                    Text("Notifications")
-                }.accessibility(identifier: "settings-notifications")
-                NavigationLink(destination: SettingsInfoFeature()) {
-                    Text("Info")
-                }.accessibility(identifier: "settings-info")
+                Button("Stampede Server", action: {})
+                Button("Repositories", action: {})
+                Button("Notifications", action: {})
+                Button("Info", action: {})
+//                NavigationLink(destination: SettingsStampedeServerFeature()) {
+//                    Text("Stampede Server")
+//                }.accessibility(identifier: "settings-stampede-server")
+//                NavigationLink(destination: SettingsRepositoriesFeature()) {
+//                    Text("Repositories")
+//                }.accessibility(identifier: "settings-repositories")
+//                NavigationLink(destination: SettingsNotificationsFeature()) {
+//                    Text("Notifications")
+//                }.accessibility(identifier: "settings-notifications")
+//                NavigationLink(destination: SettingsInfoFeature()) {
+//                    Text("Info")
+//                }.accessibility(identifier: "settings-info")
             }
-        }.listStyle(SidebarListStyle())
+        }.listStyle(GroupedListStyle())
     }
 }
 
@@ -84,7 +90,7 @@ struct MainView: View {
 struct MainView_Previews: PreviewProvider {
     static var previews: some View {        
         Previewer {
-            MainView(viewModel: MainViewModel(state: .results(Repository.someRepositories)))
+            MainView(viewModel: MainViewModel(repositories: Repository.someRepositories))
         }
     }
 }

--- a/Stampede/Stampede/Features/Main/MainViewModel.swift
+++ b/Stampede/Stampede/Features/Main/MainViewModel.swift
@@ -11,11 +11,4 @@ import SwiftUI
 import Combine
 import HouseKit
 
-class MainViewModel: ObservableObject {
-
-    @Published var repositories: [Repository]
-
-    init(repositories: [Repository] = []) {
-        self.repositories = repositories
-    }
-}
+class MainViewModel: BaseViewModel<[Repository]> { }

--- a/Stampede/Stampede/Features/Main/MainViewModel.swift
+++ b/Stampede/Stampede/Features/Main/MainViewModel.swift
@@ -11,4 +11,11 @@ import SwiftUI
 import Combine
 import HouseKit
 
-class MainViewModel: BaseViewModel<[Repository]> { }
+class MainViewModel: ObservableObject {
+
+    @Published var repositories: [Repository]
+
+    init(repositories: [Repository] = []) {
+        self.repositories = repositories
+    }
+}

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
@@ -8,7 +8,13 @@
 import UIKit
 import SwiftUI
 
-class MonitorActiveBuildsFeature: BaseFeature<Dependencies> {
+class MonitorActiveBuildsFeature: BaseFeature {
+
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return MonitorActiveBuildsFeature(dependencies: dependencies)
+    }
 
     // MARK: - Private Properties
     
@@ -18,7 +24,7 @@ class MonitorActiveBuildsFeature: BaseFeature<Dependencies> {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MonitorActiveBuildsView(viewModel: viewModel)
+                                    MonitorActiveBuildsView(viewModel: viewModel, router: self)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
@@ -24,7 +24,9 @@ class MonitorActiveBuildsFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MonitorActiveBuildsView(viewModel: viewModel, router: self)
+                                    MonitorActiveBuildsView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
@@ -5,33 +5,32 @@
 //  Created by David House on 12/3/19.
 //  Copyright © 2019 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct MonitorActiveBuildsFeature: View {
+class MonitorActiveBuildsFeature: BaseFeature<Dependencies> {
 
-    @EnvironmentObject var service: StampedeService
+    // MARK: - Private Properties
     
-    let viewModel: MonitorActiveBuildsViewModel
+    private var viewModel = MonitorActiveBuildsViewModel(state: .loading)
 
-    init(viewModel: MonitorActiveBuildsViewModel? = nil) {
-        self.viewModel = viewModel ?? MonitorActiveBuildsViewModel()
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    MonitorActiveBuildsView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
     }
     
-    var body: some View {
-        MonitorActiveBuildsView(viewModel: viewModel, publisher: service.fetchActiveBuildsPublisher())
-            .navigationBarTitle("Active Builds")
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Active Builds"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.publisher = dependencies.service.fetchActiveBuildsPublisher()
     }
 }
-
-#if DEBUG
-struct MonitorActiveBuildsFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                MonitorActiveBuildsFeature()
-            }
-        }
-    }
-}
-#endif

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
@@ -35,11 +35,7 @@ struct MonitorActiveBuildsView: View {
             List {
                 if activeBuilds.count > 0 {
                     ForEach(activeBuilds, id: \.self) { item in
-                        Button(action: {
-                            router.route(to: .buildDetails(item))
-                        }, label: {
-                            BuildStatusCell(buildStatus: item)
-                        })
+                        BuildStatusCell(buildStatus: item)
                     }
                 } else {
                     Text("No active builds found")

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
@@ -12,18 +12,8 @@ struct MonitorActiveBuildsView: View {
 
     // MARK: - View Model
     
-    @ObservedObject var viewModel: MonitorActiveBuildsViewModel
-
-    // MARK: - Properties
-    
-    weak var router: Router?
-    
-    // MARK: - Initializer
-    
-    init(viewModel: MonitorActiveBuildsViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
+    @EnvironmentObject var viewModel: MonitorActiveBuildsViewModel
+    @EnvironmentObject var router: Router
 
     // MARK: - Body
     
@@ -46,7 +36,7 @@ struct MonitorActiveBuildsView: View {
                 if activeBuilds.count > 0 {
                     ForEach(activeBuilds, id: \.self) { item in
                         Button(action: {
-                            router?.route(to: .buildDetails(item))
+                            router.route(to: .buildDetails(item))
                         }, label: {
                             BuildStatusCell(buildStatus: item)
                         })
@@ -63,9 +53,9 @@ struct MonitorActiveBuildsView: View {
 struct MonitorActiveBuildsView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            MonitorActiveBuildsView(viewModel: MonitorActiveBuildsViewModel.loading)
-            MonitorActiveBuildsView(viewModel: MonitorActiveBuildsViewModel.networkError)
-            MonitorActiveBuildsView(viewModel: MonitorActiveBuildsViewModel.someBuilds)
+            MonitorActiveBuildsView().environmentObject(MonitorActiveBuildsViewModel.loading)
+            MonitorActiveBuildsView().environmentObject(MonitorActiveBuildsViewModel.networkError)
+            MonitorActiveBuildsView().environmentObject(MonitorActiveBuildsViewModel.someBuilds)
         }
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
@@ -10,12 +10,17 @@ import SwiftUI
 
 struct MonitorActiveBuildsView: View {
 
+    // MARK: - View Model
+    
     @ObservedObject var viewModel: MonitorActiveBuildsViewModel
 
-    init(viewModel: MonitorActiveBuildsViewModel, publisher: BuildStatusResponsePublisher? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: MonitorActiveBuildsViewModel) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
     }
+
+    // MARK: - Body
     
     var body: some View {
         switch viewModel.state {

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
@@ -14,10 +14,15 @@ struct MonitorActiveBuildsView: View {
     
     @ObservedObject var viewModel: MonitorActiveBuildsViewModel
 
+    // MARK: - Properties
+    
+    weak var router: Router?
+    
     // MARK: - Initializer
     
-    init(viewModel: MonitorActiveBuildsViewModel) {
+    init(viewModel: MonitorActiveBuildsViewModel, router: Router? = nil) {
         self.viewModel = viewModel
+        self.router = router
     }
 
     // MARK: - Body
@@ -40,9 +45,11 @@ struct MonitorActiveBuildsView: View {
             List {
                 if activeBuilds.count > 0 {
                     ForEach(activeBuilds, id: \.self) { item in
-                        NavigationLink(destination: BuildFeature(buildStatus: item)) {
+                        Button(action: {
+                            router?.route(to: .buildDetails(item))
+                        }, label: {
                             BuildStatusCell(buildStatus: item)
-                        }
+                        })
                     }
                 } else {
                     Text("No active builds found")

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
@@ -5,38 +5,33 @@
 //  Created by David House on 12/6/19.
 //  Copyright © 2019 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 import Combine
 
-struct MonitorActiveTasksFeature: View {
+class MonitorActiveTasksFeature: BaseFeature<Dependencies> {
 
-    // MARK: - Environment
+    // MARK: - Private Properties
     
-    @EnvironmentObject var service: StampedeService
-    
-    let viewModel: MonitorActiveTasksViewModel
+    private var viewModel = MonitorActiveTasksViewModel(state: .loading)
 
-    init(viewModel: MonitorActiveTasksViewModel? = nil) {
-        self.viewModel = viewModel ?? MonitorActiveTasksViewModel()
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    MonitorActiveTasksView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Active Tasks"
+        navigationItem.largeTitleDisplayMode = .automatic
     }
 
-    // MARK: - View
-
-    var body: some View {
-        MonitorActiveTasksView(viewModel: viewModel, publisher: service.fetchActiveTasksPublisher())
-            .navigationBarTitle("Active Tasks")
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.publisher = dependencies.service.fetchActiveTasksPublisher()
     }
 }
-
-#if DEBUG
-struct MonitorActiveTasksFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                MonitorActiveTasksFeature()
-            }
-        }
-    }
-}
-#endif

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
@@ -25,7 +25,9 @@ class MonitorActiveTasksFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MonitorActiveTasksView(viewModel: viewModel, router: self)
+                                    MonitorActiveTasksView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
@@ -9,8 +9,14 @@ import UIKit
 import SwiftUI
 import Combine
 
-class MonitorActiveTasksFeature: BaseFeature<Dependencies> {
+class MonitorActiveTasksFeature: BaseFeature {
 
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return MonitorActiveTasksFeature(dependencies: dependencies)
+    }
+    
     // MARK: - Private Properties
     
     private var viewModel = MonitorActiveTasksViewModel(state: .loading)
@@ -19,7 +25,7 @@ class MonitorActiveTasksFeature: BaseFeature<Dependencies> {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MonitorActiveTasksView(viewModel: viewModel)
+                                    MonitorActiveTasksView(viewModel: viewModel, router: self)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
@@ -12,18 +12,8 @@ struct MonitorActiveTasksView: View {
 
     // MARK: - View Model
     
-    @ObservedObject var viewModel: MonitorActiveTasksViewModel
-
-    // MARK: - Properties
-    
-    weak var router: Router?
-    
-    // MARK: - Initializer
-    
-    init(viewModel: MonitorActiveTasksViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
+    @EnvironmentObject var viewModel: MonitorActiveTasksViewModel
+    @EnvironmentObject var router: Router
 
     // MARK: - Body
     
@@ -48,7 +38,7 @@ struct MonitorActiveTasksView: View {
                 if tasks.count > 0 {
                     ForEach(tasks, id: \.self) { item in
                         Button(action: {
-                            router?.route(to: .taskDetails(item))
+                            router.route(to: .taskDetails(item))
                         }, label: {
                             TaskStatusCell(taskStatus: item)
                         })
@@ -66,9 +56,9 @@ struct MonitorActiveTasksView: View {
 struct MonitorActiveTasksView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            MonitorActiveTasksView(viewModel: MonitorActiveTasksViewModel.loading)
-            MonitorActiveTasksView(viewModel: MonitorActiveTasksViewModel.networkError)
-            MonitorActiveTasksView(viewModel: MonitorActiveTasksViewModel.someTasks)
+            MonitorActiveTasksView().environmentObject(MonitorActiveTasksViewModel.loading)
+            MonitorActiveTasksView().environmentObject(MonitorActiveTasksViewModel.networkError)
+            MonitorActiveTasksView().environmentObject(MonitorActiveTasksViewModel.someTasks)
         }
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
@@ -10,13 +10,18 @@ import SwiftUI
 
 struct MonitorActiveTasksView: View {
 
+    // MARK: - View Model
+    
     @ObservedObject var viewModel: MonitorActiveTasksViewModel
 
-    init(viewModel: MonitorActiveTasksViewModel, publisher: TaskStatusResponsePublisher? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: MonitorActiveTasksViewModel) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
     }
 
+    // MARK: - Body
+    
     var body: some View {
         switch viewModel.state {
         case .loading:

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
@@ -14,10 +14,15 @@ struct MonitorActiveTasksView: View {
     
     @ObservedObject var viewModel: MonitorActiveTasksViewModel
 
+    // MARK: - Properties
+    
+    weak var router: Router?
+    
     // MARK: - Initializer
     
-    init(viewModel: MonitorActiveTasksViewModel) {
+    init(viewModel: MonitorActiveTasksViewModel, router: Router? = nil) {
         self.viewModel = viewModel
+        self.router = router
     }
 
     // MARK: - Body
@@ -42,9 +47,11 @@ struct MonitorActiveTasksView: View {
             List {
                 if tasks.count > 0 {
                     ForEach(tasks, id: \.self) { item in
-                        NavigationLink(destination: BuildTaskFeature(task: item)) {
+                        Button(action: {
+                            router?.route(to: .taskDetails(item))
+                        }, label: {
                             TaskStatusCell(taskStatus: item)
-                        }
+                        })
                     }
                 } else {
                     Text("No active tasks found")

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
@@ -5,57 +5,33 @@
 //  Created by David House on 6/3/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 import Combine
 
-struct MonitorLiveFeature: View {
+class MonitorLiveFeature: BaseFeature<Dependencies> {
 
-    // MARK: - Environment
+    // MARK: - Private Properties
+    
+    private var viewModel = MonitorLiveViewModel(state: .loading)
 
-    @EnvironmentObject var service: StampedeService
-
-    // MARK: Properties
-
-    @State var viewModel: MonitorLiveViewModel = MonitorLiveViewModel()
-
-    // MARK: Initializer
-
-    init(gauges: [MonitorLiveViewModelQueue]? = nil) {
-        if let gauges = gauges {
-            viewModel.queueGauges = gauges
-        }
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    MonitorLiveView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
     }
 
-    // MARK: Body
-
-    var body: some View {
-        MonitorLiveView(viewModel: viewModel)
-            .navigationBarTitle("Live Status")
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Live Status"
+        navigationItem.largeTitleDisplayMode = .automatic
     }
-}
 
-#if DEBUG
-struct MonitorLiveFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                MonitorLiveFeature(gauges: [
-                    MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
-                        MonitorLiveViewModel.idleQueue,
-                        MonitorLiveViewModel.idleQueue,
-                        MonitorLiveViewModel.partialQueue,
-                        MonitorLiveViewModel.partialQueue,
-                        MonitorLiveViewModel.idleQueue,
-                        MonitorLiveViewModel.idleQueue,
-                        MonitorLiveViewModel.idleQueue,
-                        MonitorLiveViewModel.fullQueue,
-                        MonitorLiveViewModel.fullQueue,
-                        MonitorLiveViewModel.fullQueue
-                    ])
-                ])
-            }
-        }
+    override func viewDidAppear(_ animated: Bool) {
+        
     }
 }
-#endif

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
@@ -9,8 +9,14 @@ import UIKit
 import SwiftUI
 import Combine
 
-class MonitorLiveFeature: BaseFeature<Dependencies> {
+class MonitorLiveFeature: BaseFeature {
 
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return MonitorLiveFeature(dependencies: dependencies)
+    }
+    
     // MARK: - Private Properties
     
     private var viewModel = MonitorLiveViewModel(state: .loading)

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
@@ -25,7 +25,8 @@ class MonitorLiveFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MonitorLiveView(viewModel: viewModel)
+                                    MonitorLiveView()
+                                    .environmentObject(viewModel)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
@@ -26,15 +26,23 @@ struct MonitorLiveView: View {
 
     // MARK: - View
     var body: some View {
-        ScrollView {
-            LazyVGrid(columns: columns) {
-                ForEach(viewModel.queueGauges, id: \.self) { gauge in
-                    VStack {
-                        QueueChartView(measurements: gauge.history).aspectRatio(contentMode: .fit)
-                        PrimaryLabel(gauge.title)
-                    }
-                }
-            }
+        switch viewModel.state {
+        case .loading:
+            Text("Loading...")
+        case .networkError:
+            Text("Network Error...")
+        case .results(let results):
+//            ScrollView {
+//                LazyVGrid(columns: columns) {
+//                    ForEach(viewModel.queueGauges, id: \.self) { gauge in
+//                        VStack {
+//                            QueueChartView(measurements: gauge.history).aspectRatio(contentMode: .fit)
+//                            PrimaryLabel(gauge.title)
+//                        }
+//                    }
+//                }
+//            }
+        Text("Results?")
         }
     }
 }
@@ -43,12 +51,12 @@ struct MonitorLiveView: View {
 struct MonitorLiveView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            MonitorLiveView(viewModel: MonitorLiveViewModel.oneIdleQueue).previewDependencies()
-            MonitorLiveView(viewModel: MonitorLiveViewModel.onePartialQueue).previewDependencies()
-            MonitorLiveView(viewModel: MonitorLiveViewModel.oneFullQueue).previewDependencies()
-            MonitorLiveView(viewModel: MonitorLiveViewModel.oneQueuedQueue).previewDependencies()
-            MonitorLiveView(viewModel: MonitorLiveViewModel.twoQueues).previewDependencies()
-            MonitorLiveView(viewModel: MonitorLiveViewModel.allQueues).previewDependencies()
+//            MonitorLiveView(viewModel: MonitorLiveViewModel.oneIdleQueue).previewDependencies()
+//            MonitorLiveView(viewModel: MonitorLiveViewModel.onePartialQueue).previewDependencies()
+//            MonitorLiveView(viewModel: MonitorLiveViewModel.oneFullQueue).previewDependencies()
+//            MonitorLiveView(viewModel: MonitorLiveViewModel.oneQueuedQueue).previewDependencies()
+//            MonitorLiveView(viewModel: MonitorLiveViewModel.twoQueues).previewDependencies()
+//            MonitorLiveView(viewModel: MonitorLiveViewModel.allQueues).previewDependencies()
         }
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
@@ -14,11 +14,7 @@ struct MonitorLiveView: View {
 
     // MARK: - Observed Objects
 
-    @ObservedObject var viewModel: MonitorLiveViewModel
-    
-    init(viewModel: MonitorLiveViewModel) {
-        self.viewModel = viewModel
-    }
+    @EnvironmentObject var viewModel: MonitorLiveViewModel
     
     private var columns: [GridItem] = [
         GridItem(.adaptive(minimum: 300))

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
@@ -38,7 +38,7 @@ struct MonitorLiveView: View {
 //                    }
 //                }
 //            }
-        Text("Results?")
+            Text("Results?")
         }
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveViewModel.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveViewModel.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import Combine
+import HouseKit
 
 struct MonitorLiveViewModelQueue: Hashable {
     let title: String
@@ -15,45 +16,45 @@ struct MonitorLiveViewModelQueue: Hashable {
     let history: [QueueGaugeInfo]
 }
 
-class MonitorLiveViewModel: ObservableObject {
+class MonitorLiveViewModel: BaseViewModel<[MonitorLiveViewModelQueue]> {
 
     // MARK: - Published properties
-    @Published var queueGauges: [MonitorLiveViewModelQueue]
+//    @Published var queueGauges: [MonitorLiveViewModelQueue]
 
-    private var workers: [WorkerStatus] = [] {
-        didSet {
-            self.recalculate()
-        }
-    }
-
-    private var queues: [QueueSummary] = [] {
-        didSet {
-            self.recalculate()
-        }
-    }
-
-    // MARK: - Properties
-
-    var workersPublisher: AnyPublisher<[WorkerStatus], StampedeError>? {
-        didSet {
-            // self.fetch()
-        }
-    }
-
-    var queuesPublisher: AnyPublisher<[QueueSummary], StampedeError>? {
-        didSet {
-            // self.fetch()
-        }
-    }
-
-    // MARK: - Initializer
-    init(gauges: [MonitorLiveViewModelQueue]? = nil) {
-        if let gauges = gauges {
-            self.queueGauges = gauges
-        } else {
-            self.queueGauges = []
-        }
-    }
+//    private var workers: [WorkerStatus] = [] {
+//        didSet {
+//            self.recalculate()
+//        }
+//    }
+//
+//    private var queues: [QueueSummary] = [] {
+//        didSet {
+//            self.recalculate()
+//        }
+//    }
+//
+//    // MARK: - Properties
+//
+//    var workersPublisher: AnyPublisher<[WorkerStatus], StampedeError>? {
+//        didSet {
+//            // self.fetch()
+//        }
+//    }
+//
+//    var queuesPublisher: AnyPublisher<[QueueSummary], StampedeError>? {
+//        didSet {
+//            // self.fetch()
+//        }
+//    }
+//
+//    // MARK: - Initializer
+//    init(gauges: [MonitorLiveViewModelQueue]? = nil) {
+//        if let gauges = gauges {
+//            self.queueGauges = gauges
+//        } else {
+//            self.queueGauges = []
+//        }
+//    }
 
 //    func fetch() {
 //        self.workersPublisher?.sink(receiveCompletion: { result in
@@ -91,29 +92,29 @@ class MonitorLiveViewModel: ObservableObject {
 //        }).store(in: &self.disposables)
 //    }
 
-    private func recalculate() {
-        var updatedQueues: [MonitorLiveViewModelQueue] = []
-
-        for queue in queues {
-            let activeCount = workers.filter({ $0.taskQueue == queue.queue && $0.status == "busy" }).count
-            let inactiveCount = workers.filter({ $0.taskQueue == queue.queue && $0.status == "idle" }).count
-            let info = QueueGaugeInfo(title: queue.queue, idle: inactiveCount, active: activeCount, queued: queue.stats.waiting)
-            if info.idle > 0 || info.active > 0 || info.queued > 0 {
-                if let existing = queueGauges.filter({ $0.title == queue.queue }).first {
-                    var existingHistory = existing.history
-                    existingHistory.append(info)
-                    if existingHistory.count > 50 {
-                        existingHistory.remove(at: 0)
-                    }
-                    updatedQueues.append(MonitorLiveViewModelQueue(title: queue.queue, gauge: info, history: existingHistory))
-                } else {
-                    updatedQueues.append(MonitorLiveViewModelQueue(title: queue.queue, gauge: info, history: [info]))
-                }
-            }
-        }
-
-        queueGauges = updatedQueues
-    }
+//    private func recalculate() {
+//        var updatedQueues: [MonitorLiveViewModelQueue] = []
+//
+//        for queue in queues {
+//            let activeCount = workers.filter({ $0.taskQueue == queue.queue && $0.status == "busy" }).count
+//            let inactiveCount = workers.filter({ $0.taskQueue == queue.queue && $0.status == "idle" }).count
+//            let info = QueueGaugeInfo(title: queue.queue, idle: inactiveCount, active: activeCount, queued: queue.stats.waiting)
+//            if info.idle > 0 || info.active > 0 || info.queued > 0 {
+//                if let existing = queueGauges.filter({ $0.title == queue.queue }).first {
+//                    var existingHistory = existing.history
+//                    existingHistory.append(info)
+//                    if existingHistory.count > 50 {
+//                        existingHistory.remove(at: 0)
+//                    }
+//                    updatedQueues.append(MonitorLiveViewModelQueue(title: queue.queue, gauge: info, history: existingHistory))
+//                } else {
+//                    updatedQueues.append(MonitorLiveViewModelQueue(title: queue.queue, gauge: info, history: [info]))
+//                }
+//            }
+//        }
+//
+//        queueGauges = updatedQueues
+//    }
 }
 
 #if DEBUG
@@ -136,131 +137,131 @@ extension MonitorLiveViewModel {
         MonitorLiveViewModel.idleQueue
     ]
 
-    static var oneIdleQueue = MonitorLiveViewModel(gauges: [
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.idleQueue, history: MonitorLiveViewModel.idleHistory)
-    ])
-
-    static var onePartialQueue = MonitorLiveViewModel(gauges: [
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.partialQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue
-        ])
-    ])
-
-    static var oneFullQueue = MonitorLiveViewModel(gauges: [
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.fullQueue,
-            MonitorLiveViewModel.fullQueue,
-            MonitorLiveViewModel.fullQueue
-        ])
-    ])
-
-    static var oneQueuedQueue = MonitorLiveViewModel(gauges: [
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.queuedQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.queuedQueue,
-            MonitorLiveViewModel.queuedQueue
-        ])
-    ])
-
-    static var twoQueues = MonitorLiveViewModel(gauges: [
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.queuedQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.queuedQueue,
-            MonitorLiveViewModel.queuedQueue
-        ]),
-        MonitorLiveViewModelQueue(title: "otherQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.fullQueue,
-            MonitorLiveViewModel.fullQueue,
-            MonitorLiveViewModel.fullQueue
-        ])
-    ])
-    
-    static var allQueues = MonitorLiveViewModel(gauges: [
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.queuedQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.queuedQueue,
-            MonitorLiveViewModel.queuedQueue
-        ]),
-        MonitorLiveViewModelQueue(title: "otherQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.fullQueue,
-            MonitorLiveViewModel.fullQueue,
-            MonitorLiveViewModel.fullQueue
-        ]),
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.idleQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue
-        ]),
-        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.partialQueue, history: [
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.idleQueue,
-            MonitorLiveViewModel.partialQueue,
-            MonitorLiveViewModel.partialQueue
-        ])
-    ])
+//    static var oneIdleQueue = MonitorLiveViewModel(gauges: [
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.idleQueue, history: MonitorLiveViewModel.idleHistory)
+//    ])
+//
+//    static var onePartialQueue = MonitorLiveViewModel(gauges: [
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.partialQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue
+//        ])
+//    ])
+//
+//    static var oneFullQueue = MonitorLiveViewModel(gauges: [
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.fullQueue,
+//            MonitorLiveViewModel.fullQueue,
+//            MonitorLiveViewModel.fullQueue
+//        ])
+//    ])
+//
+//    static var oneQueuedQueue = MonitorLiveViewModel(gauges: [
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.queuedQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.queuedQueue,
+//            MonitorLiveViewModel.queuedQueue
+//        ])
+//    ])
+//
+//    static var twoQueues = MonitorLiveViewModel(gauges: [
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.queuedQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.queuedQueue,
+//            MonitorLiveViewModel.queuedQueue
+//        ]),
+//        MonitorLiveViewModelQueue(title: "otherQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.fullQueue,
+//            MonitorLiveViewModel.fullQueue,
+//            MonitorLiveViewModel.fullQueue
+//        ])
+//    ])
+//    
+//    static var allQueues = MonitorLiveViewModel(gauges: [
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.queuedQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.queuedQueue,
+//            MonitorLiveViewModel.queuedQueue
+//        ]),
+//        MonitorLiveViewModelQueue(title: "otherQueue", gauge: MonitorLiveViewModel.fullQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.fullQueue,
+//            MonitorLiveViewModel.fullQueue,
+//            MonitorLiveViewModel.fullQueue
+//        ]),
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.idleQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue
+//        ]),
+//        MonitorLiveViewModelQueue(title: "someQueue", gauge: MonitorLiveViewModel.partialQueue, history: [
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.idleQueue,
+//            MonitorLiveViewModel.partialQueue,
+//            MonitorLiveViewModel.partialQueue
+//        ])
+//    ])
 }
 #endif

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesFeature.swift
@@ -5,36 +5,33 @@
 //  Created by David House on 12/6/19.
 //  Copyright © 2019 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 import Combine
 
-struct MonitorQueuesFeature: View {
+class MonitorQueuesFeature: BaseFeature<Dependencies> {
 
-    @EnvironmentObject var service: StampedeService
+    // MARK: - Private Properties
+    
+    private var viewModel = MonitorQueuesViewModel(state: .loading)
 
-    let viewModel: MonitorQueuesViewModel
-
-    init(viewModel: MonitorQueuesViewModel? = nil) {
-        self.viewModel = viewModel ?? MonitorQueuesViewModel()
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    MonitorQueuesView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Queue Status"
+        navigationItem.largeTitleDisplayMode = .automatic
     }
 
-    // MARK: - View
-
-    var body: some View {
-        MonitorQueuesView(viewModel: viewModel, publisher: service.fetchMonitorQueuesPublisher())
-            .navigationBarTitle("Queues")
-    }
-}
-
-#if DEBUG
-struct MonitorQueuesFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                MonitorQueuesFeature()
-            }
-        }
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.publisher = dependencies.service.fetchMonitorQueuesPublisher()
     }
 }
-#endif

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesFeature.swift
@@ -9,8 +9,14 @@ import UIKit
 import SwiftUI
 import Combine
 
-class MonitorQueuesFeature: BaseFeature<Dependencies> {
+class MonitorQueuesFeature: BaseFeature {
 
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return MonitorQueuesFeature(dependencies: dependencies)
+    }
+    
     // MARK: - Private Properties
     
     private var viewModel = MonitorQueuesViewModel(state: .loading)

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesFeature.swift
@@ -25,7 +25,9 @@ class MonitorQueuesFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    MonitorQueuesView(viewModel: viewModel)
+                                    MonitorQueuesView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
@@ -12,13 +12,7 @@ struct MonitorQueuesView: View {
 
     // MARK: - View Model
     
-    @ObservedObject var viewModel: MonitorQueuesViewModel
-
-    // MARK: - Initializer
-    
-    init(viewModel: MonitorQueuesViewModel) {
-        self.viewModel = viewModel
-    }
+    @EnvironmentObject var viewModel: MonitorQueuesViewModel
 
     // MARK: - Body
     
@@ -57,9 +51,9 @@ struct MonitorQueuesView: View {
 struct MonitorQueuesView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            MonitorQueuesView(viewModel: MonitorQueuesViewModel.loading)
-            MonitorQueuesView(viewModel: MonitorQueuesViewModel.networkError)
-            MonitorQueuesView(viewModel: MonitorQueuesViewModel.someQueues)
+            MonitorQueuesView().environmentObject(MonitorQueuesViewModel.loading)
+            MonitorQueuesView().environmentObject(MonitorQueuesViewModel.networkError)
+            MonitorQueuesView().environmentObject(MonitorQueuesViewModel.someQueues)
         }
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
@@ -10,13 +10,18 @@ import SwiftUI
 
 struct MonitorQueuesView: View {
 
+    // MARK: - View Model
+    
     @ObservedObject var viewModel: MonitorQueuesViewModel
 
-    init(viewModel: MonitorQueuesViewModel, publisher: QueueSummaryResponsePublisher? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: MonitorQueuesViewModel) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
     }
 
+    // MARK: - Body
+    
     var body: some View {
         switch viewModel.state {
         case .loading:

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryFeature.swift
@@ -5,10 +5,10 @@
 //  Created by David House on 12/2/19.
 //  Copyright © 2019 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct RepositoryFeature: View {
+class RepositoryFeature: BaseFeature<Dependencies> {
 
     let repository: Repository
 
@@ -20,25 +20,33 @@ struct RepositoryFeature: View {
 
     let viewModel: RepositoryViewModel
 
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    RepositoryView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
+    }
+    
     // MARK: Initializer
 
-    init(repository: Repository, viewModel: RepositoryViewModel? = nil) {
-        self.viewModel = viewModel ?? RepositoryViewModel()
-        self.repository = repository
-    }
+//    init(repository: Repository, viewModel: RepositoryViewModel? = nil) {
+//        self.viewModel = viewModel ?? RepositoryViewModel()
+//        self.repository = repository
+//    }
 
-    // MARK: - View
-
-    var body: some View {
-        RepositoryView(viewModel: viewModel,
-                       activeBuildsPublisher: service.fetchActiveBuildsPublisher(owner: repository.owner, repository: repository.repository),
-                       repositoryBuildsPublisher: service.fetchRepositoryBuildsPublisher(owner: repository.owner, repository: repository.repository),
-                       branchKeysPublisher: service.fetchBuildKeysPublisher(owner: repository.owner, repository: repository.repository, source: "branch-push"),
-                       releaseKeysPublisher: service.fetchBuildKeysPublisher(owner: repository.owner, repository: repository.repository, source: "release"),
-                       pullRequestKeysPublisher: service.fetchBuildKeysPublisher(owner: repository.owner, repository: repository.repository, source: "pull-request")
-                       )
-            .navigationBarTitle(repository.repository)
-    }
+//    // MARK: - View
+//
+//    var body: some View {
+//        RepositoryView(viewModel: viewModel,
+//                       activeBuildsPublisher: service.fetchActiveBuildsPublisher(owner: repository.owner, repository: repository.repository),
+//                       repositoryBuildsPublisher: service.fetchRepositoryBuildsPublisher(owner: repository.owner, repository: repository.repository),
+//                       branchKeysPublisher: service.fetchBuildKeysPublisher(owner: repository.owner, repository: repository.repository, source: "branch-push"),
+//                       releaseKeysPublisher: service.fetchBuildKeysPublisher(owner: repository.owner, repository: repository.repository, source: "release"),
+//                       pullRequestKeysPublisher: service.fetchBuildKeysPublisher(owner: repository.owner, repository: repository.repository, source: "pull-request")
+//                       )
+//            .navigationBarTitle(repository.repository)
+//    }
 }
 
 #if DEBUG

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryFeature.swift
@@ -41,7 +41,9 @@ class RepositoryFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    RepositoryView(viewModel: viewModel, router: self)
+                                    RepositoryView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
@@ -63,11 +63,7 @@ struct RepositoryView: View {
         case .results(let activeBuilds):
             if activeBuilds.count > 0 {
                 ForEach(activeBuilds, id: \.self) { item in
-                    Button(action: {
-                        router.route(to: .buildDetails(item))
-                    }, label: {
-                        BuildStatusCell(buildStatus: item)
-                    })
+                    BuildStatusCell(buildStatus: item)
                 }
             } else {
                 Text("No active builds found")

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
@@ -12,25 +12,19 @@ import Combine
 
 struct RepositoryView: View {
 
-    // MARK: - Environment
-
-    // MARK: - Properties
-
+    // MARK: - Private Properties
+    
+    let router: Router?
+    
     // MARK: - Observed objects
 
     @ObservedObject var viewModel: RepositoryViewModel
 
-    init(viewModel: RepositoryViewModel, activeBuildsPublisher: BuildStatusResponsePublisher? = nil,
-         repositoryBuildsPublisher: RepositoryBuildResponsePublisher? = nil,
-         branchKeysPublisher: BuildKeyResponsePublisher? = nil,
-         releaseKeysPublisher: BuildKeyResponsePublisher? = nil,
-         pullRequestKeysPublisher: BuildKeyResponsePublisher? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: RepositoryViewModel, router: Router? = nil) {
         self.viewModel = viewModel
-        self.viewModel.activeBuildsPublisher = activeBuildsPublisher
-        self.viewModel.repositoryBuildsPublisher = repositoryBuildsPublisher
-        self.viewModel.branchKeysPublisher = branchKeysPublisher
-        self.viewModel.releaseKeysPublisher = releaseKeysPublisher
-        self.viewModel.pullRequestKeysPublisher = pullRequestKeysPublisher
+        self.router = router
     }
 
     // MARK: - View
@@ -79,9 +73,11 @@ struct RepositoryView: View {
         case .results(let activeBuilds):
             if activeBuilds.count > 0 {
                 ForEach(activeBuilds, id: \.self) { item in
-                    NavigationLink(destination: BuildFeature(buildStatus: item)) {
+                    Button(action: {
+                        router?.route(to: .buildDetails(item))
+                    }, label: {
                         BuildStatusCell(buildStatus: item)
-                    }
+                    })
                 }
             } else {
                 Text("No active builds found")

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
@@ -11,21 +11,11 @@ import HouseKit
 import Combine
 
 struct RepositoryView: View {
-
-    // MARK: - Private Properties
-    
-    let router: Router?
     
     // MARK: - Observed objects
 
-    @ObservedObject var viewModel: RepositoryViewModel
-
-    // MARK: - Initializer
-    
-    init(viewModel: RepositoryViewModel, router: Router? = nil) {
-        self.viewModel = viewModel
-        self.router = router
-    }
+    @EnvironmentObject var viewModel: RepositoryViewModel
+    @EnvironmentObject var router: Router
 
     // MARK: - View
 
@@ -74,7 +64,7 @@ struct RepositoryView: View {
             if activeBuilds.count > 0 {
                 ForEach(activeBuilds, id: \.self) { item in
                     Button(action: {
-                        router?.route(to: .buildDetails(item))
+                        router.route(to: .buildDetails(item))
                     }, label: {
                         BuildStatusCell(buildStatus: item)
                     })
@@ -192,8 +182,7 @@ struct RepositoryView: View {
 struct RepositoryView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            RepositoryView(viewModel:
-                        RepositoryViewModel.someViewModel)
+            RepositoryView().environmentObject(RepositoryViewModel.someViewModel)
         }
     }
 }

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryViewModel.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryViewModel.swift
@@ -64,28 +64,9 @@ class RepositoryViewModel: ObservableObject {
 
     // MARK: - Initializer
 
-    init(activeBuildsState: ViewModelState<[BuildStatus]> = .loading,
-         activeBuildsPublisher: BuildStatusResponsePublisher? = nil,
-         repositoryBuildsState: ViewModelState<[RepositoryBuild]> = .loading,
-         repositoryBuildsPublisher: RepositoryBuildResponsePublisher? = nil,
-         branchKeysState: ViewModelState<[BuildKey]> = .loading,
-         branchKeysPublisher: BuildKeyResponsePublisher? = nil,
-         releaseKeysState: ViewModelState<[BuildKey]> = .loading,
-         releaseKeysPublisher: BuildKeyResponsePublisher? = nil,
-         pullRequestKeysState: ViewModelState<[BuildKey]> = .loading,
-         pullRequestKeysPublisher: BuildKeyResponsePublisher? = nil) {
+    init(activeBuildsState: ViewModelState<[BuildStatus]> = .loading, repositoryBuildsState: ViewModelState<[RepositoryBuild]> = .loading) {
         self.activeBuildsState = activeBuildsState
-        self.activeBuildsPublisher = activeBuildsPublisher
         self.repositoryBuildsState = repositoryBuildsState
-        self.repositoryBuildsPublisher = repositoryBuildsPublisher
-        self.branchKeysState = branchKeysState
-        self.branchKeysPublisher = branchKeysPublisher
-        self.releaseKeysState = releaseKeysState
-        self.releaseKeysPublisher = releaseKeysPublisher
-        self.pullRequestKeysState = pullRequestKeysState
-        self.pullRequestKeysPublisher = pullRequestKeysPublisher
-        fetchActiveBuilds()
-        fetchRepositoryBuilds()
     }
 
     private func fetchActiveBuilds() {

--- a/Stampede/Stampede/Features/Settings/Info/SettingsInfoFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Info/SettingsInfoFeature.swift
@@ -5,27 +5,31 @@
 //  Created by David House on 7/11/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct SettingsInfoFeature: View {
+class SettingsInfoFeature: BaseFeature<Dependencies> {
 
-    @State var viewModel: SettingsInfoViewModel = SettingsInfoViewModel()
+    // MARK: - Private Properties
     
-    var body: some View {
-        SettingsInfoView(viewModel: viewModel)
-            .navigationBarTitle("About Stampede")
+    private var viewModel = SettingsInfoViewModel()
+    
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    SettingsInfoView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
     }
-}
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Stampede Info"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
 
-#if DEBUG
-struct SettingsInfoFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                SettingsInfoFeature()
-            }
-        }
+    override func viewDidAppear(_ animated: Bool) {
     }
 }
-#endif

--- a/Stampede/Stampede/Features/Settings/Info/SettingsInfoFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Info/SettingsInfoFeature.swift
@@ -8,8 +8,14 @@
 import UIKit
 import SwiftUI
 
-class SettingsInfoFeature: BaseFeature<Dependencies> {
+class SettingsInfoFeature: BaseFeature {
 
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return SettingsInfoFeature(dependencies: dependencies)
+    }
+    
     // MARK: - Private Properties
     
     private var viewModel = SettingsInfoViewModel()

--- a/Stampede/Stampede/Features/Settings/Info/SettingsInfoFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Info/SettingsInfoFeature.swift
@@ -24,7 +24,9 @@ class SettingsInfoFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    SettingsInfoView(viewModel: viewModel)
+                                    SettingsInfoView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Settings/Info/SettingsInfoView.swift
+++ b/Stampede/Stampede/Features/Settings/Info/SettingsInfoView.swift
@@ -16,7 +16,7 @@ struct SettingsInfoView: View {
 
     // MARK: - Observed Objects
 
-    @ObservedObject var viewModel: SettingsInfoViewModel
+    @EnvironmentObject var viewModel: SettingsInfoViewModel
 
     var body: some View {
         List {
@@ -34,6 +34,6 @@ struct SettingsInfoView: View {
 
 struct SettingsInfoView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsInfoView(viewModel: SettingsInfoViewModel())
+        SettingsInfoView().environmentObject(SettingsInfoViewModel())
     }
 }

--- a/Stampede/Stampede/Features/Settings/Notifications/SettingsNotificationsFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Notifications/SettingsNotificationsFeature.swift
@@ -8,7 +8,13 @@
 import UIKit
 import SwiftUI
 
-class SettingsNotificationsFeature: BaseFeature<Dependencies> {
+class SettingsNotificationsFeature: BaseFeature {
+    
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return SettingsNotificationsFeature(dependencies: dependencies)
+    }
     
     // MARK: - Private Properties
     

--- a/Stampede/Stampede/Features/Settings/Notifications/SettingsNotificationsFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Notifications/SettingsNotificationsFeature.swift
@@ -5,24 +5,29 @@
 //  Created by David House on 7/11/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct SettingsNotificationsFeature: View {
-    var body: some View {
-        SettingsNotificationsView()
-            .navigationBarTitle("Notifications")
+class SettingsNotificationsFeature: BaseFeature<Dependencies> {
+    
+    // MARK: - Private Properties
+    
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    SettingsNotificationsView()
+                                    .dependenciesToEnvironment(dependencies))
     }
-}
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Notifications"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
 
-#if DEBUG
-struct SettingsNotificationFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                SettingsNotificationsFeature()
-            }
-        }
+    override func viewDidAppear(_ animated: Bool) {
     }
 }
-#endif

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
@@ -6,35 +6,72 @@
 //  Copyright © 2020 David House. All rights reserved.
 //
 
+import UIKit
 import SwiftUI
+import Combine
+import HouseKit
 
-struct SelectRepositoryFeature: View {
-    @EnvironmentObject var service: StampedeService
+class SelectRepositoryFeature: BaseFeature<Dependencies> {
     
-    let viewModel: SelectRepositoryViewModel
-    let onSelected: (Repository) -> Void
-    
-    init(viewModel: SelectRepositoryViewModel? = nil, onSelected: @escaping (Repository) -> Void) {
-        self.viewModel = viewModel ?? SelectRepositoryViewModel()
-        self.onSelected = onSelected
-    }
-        
-    var body: some View {
-        NavigationView {
-            SelectRepositoryView(viewModel: viewModel, publisher: service.fetchRepositoriesPublisher(), onSelected: onSelected)
-                .navigationBarTitle("Select Repository")
-        }
-    }
-}
+    let viewModel = SelectRepositoryViewModel(state: .loading)
+    var publisher: AnyPublisher<[Repository], ServiceError>?
+    private var disposables = Set<AnyCancellable>()
 
-#if DEBUG
-struct SelectRepositoryFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                SelectRepositoryFeature(onSelected: { _ in })
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    SelectRepositoryView(viewModel: viewModel, onSelected: { repository in
+                                        self.dependencies.repositoryList.addRepository(repository: repository)
+                                        self.dismiss(animated: true, completion: {})
+                                    })
+                                    .dependenciesToEnvironment(dependencies))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Add Favorite"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        publisher = dependencies.service.fetchRepositoriesPublisher()
+        self.publisher?.sink(receiveCompletion: { result in
+          if case let .failure(error) = result {
+            print("Error receiving \(error)")
+            DispatchQueue.main.async {
+                self.viewModel.state = .networkError
             }
-        }
+          }
+        }, receiveValue: { value in
+            DispatchQueue.main.async {
+                self.viewModel.state = .results(value)
+            }
+        }).store(in: &self.disposables)
     }
+    
+//    let viewModel: SelectRepositoryViewModel
+//    let onSelected: (Repository) -> Void
+//    
+//    init(viewModel: SelectRepositoryViewModel? = nil, onSelected: @escaping (Repository) -> Void) {
+//        self.viewModel = viewModel ?? SelectRepositoryViewModel()
+//        self.onSelected = onSelected
+//    }
+//        
+//    var body: some View {
+//        NavigationView {
+//            SelectRepositoryView(viewModel: viewModel, publisher: service.fetchRepositoriesPublisher(), onSelected: onSelected)
+//                .navigationBarTitle("Select Repository")
+//        }
+//    }
 }
-#endif
+
+//#if DEBUG
+//struct SelectRepositoryFeature_Previews: PreviewProvider {
+//    static var previews: some View {
+//        DevicePreviewer {
+//            NavigationView {
+//                SelectRepositoryFeature(onSelected: { _ in })
+//            }
+//        }
+//    }
+//}
+//#endif

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
@@ -13,21 +13,21 @@ import HouseKit
 
 class SelectRepositoryFeature: BaseFeature<Dependencies> {
     
-    let viewModel = SelectRepositoryViewModel(state: .loading)
-    var publisher: AnyPublisher<[Repository], ServiceError>?
-    private var disposables = Set<AnyCancellable>()
-    weak var delegate: SelectRepositoryDelegate?
+    // MARK: - Private Properties
+    
+    private let viewModel = SelectRepositoryViewModel(state: .loading)
+    private weak var delegate: SelectRepositoryDelegate?
 
+    // MARK: - Overrides
+    
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
                                     SelectRepositoryView(viewModel: viewModel, delegate: delegate)
-//                                    { repository in
-//                                        self.dependencies.repositoryList.addRepository(repository: repository)
-//                                        self.dismiss(animated: true, completion: {})
-//                                    })
-                                    .dependenciesToEnvironment(dependencies))
+                                        .dependenciesToEnvironment(dependencies))
     }
 
+    // MARK: - Initializers
+    
     init(dependencies: Dependencies, delegate: SelectRepositoryDelegate?) {
         self.delegate = delegate
         super.init(dependencies: dependencies)
@@ -37,6 +37,8 @@ class SelectRepositoryFeature: BaseFeature<Dependencies> {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // MARK: - View Lifecycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Add Favorite"
@@ -44,45 +46,6 @@ class SelectRepositoryFeature: BaseFeature<Dependencies> {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        publisher = dependencies.service.fetchRepositoriesPublisher()
-        self.publisher?.sink(receiveCompletion: { result in
-          if case let .failure(error) = result {
-            print("Error receiving \(error)")
-            DispatchQueue.main.async {
-                self.viewModel.state = .networkError
-            }
-          }
-        }, receiveValue: { value in
-            DispatchQueue.main.async {
-                self.viewModel.state = .results(value)
-            }
-        }).store(in: &self.disposables)
+        viewModel.publisher = dependencies.service.fetchRepositoriesPublisher()
     }
-    
-//    let viewModel: SelectRepositoryViewModel
-//    let onSelected: (Repository) -> Void
-//    
-//    init(viewModel: SelectRepositoryViewModel? = nil, onSelected: @escaping (Repository) -> Void) {
-//        self.viewModel = viewModel ?? SelectRepositoryViewModel()
-//        self.onSelected = onSelected
-//    }
-//        
-//    var body: some View {
-//        NavigationView {
-//            SelectRepositoryView(viewModel: viewModel, publisher: service.fetchRepositoriesPublisher(), onSelected: onSelected)
-//                .navigationBarTitle("Select Repository")
-//        }
-//    }
 }
-
-//#if DEBUG
-//struct SelectRepositoryFeature_Previews: PreviewProvider {
-//    static var previews: some View {
-//        DevicePreviewer {
-//            NavigationView {
-//                SelectRepositoryFeature(onSelected: { _ in })
-//            }
-//        }
-//    }
-//}
-//#endif

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
@@ -22,7 +22,9 @@ class SelectRepositoryFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    SelectRepositoryView(viewModel: viewModel, delegate: delegate)
+                                    SelectRepositoryView(delegate: delegate)
+                                        .environmentObject(viewModel)
+                                        .environmentObject(router)
                                         .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import Combine
 import HouseKit
 
-class SelectRepositoryFeature: BaseFeature<Dependencies> {
+class SelectRepositoryFeature: BaseFeature {
     
     // MARK: - Private Properties
     

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
@@ -16,16 +16,27 @@ class SelectRepositoryFeature: BaseFeature<Dependencies> {
     let viewModel = SelectRepositoryViewModel(state: .loading)
     var publisher: AnyPublisher<[Repository], ServiceError>?
     private var disposables = Set<AnyCancellable>()
+    weak var delegate: SelectRepositoryDelegate?
 
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    SelectRepositoryView(viewModel: viewModel, onSelected: { repository in
-                                        self.dependencies.repositoryList.addRepository(repository: repository)
-                                        self.dismiss(animated: true, completion: {})
-                                    })
+                                    SelectRepositoryView(viewModel: viewModel, delegate: delegate)
+//                                    { repository in
+//                                        self.dependencies.repositoryList.addRepository(repository: repository)
+//                                        self.dismiss(animated: true, completion: {})
+//                                    })
                                     .dependenciesToEnvironment(dependencies))
     }
 
+    init(dependencies: Dependencies, delegate: SelectRepositoryDelegate?) {
+        self.delegate = delegate
+        super.init(dependencies: dependencies)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "Add Favorite"

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
@@ -10,14 +10,18 @@ import SwiftUI
 import HouseKit
 import Combine
 
+protocol SelectRepositoryDelegate: class {
+    func didSelectRepository(_ repository: Repository)
+}
+
 struct SelectRepositoryView: View {
     
     @ObservedObject var viewModel: SelectRepositoryViewModel
-    let onSelected: (Repository) -> Void
+    weak var delegate: SelectRepositoryDelegate?
 
-    init(viewModel: SelectRepositoryViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, onSelected: @escaping (Repository) -> Void) {
+    init(viewModel: SelectRepositoryViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, delegate: SelectRepositoryDelegate? = nil) {
         self.viewModel = viewModel
-        self.onSelected = onSelected
+        self.delegate = delegate
         self.viewModel.publisher = publisher
     }
     
@@ -34,7 +38,7 @@ struct SelectRepositoryView: View {
                         RepositoryCell(repository: item)
                             .contentShape(Rectangle())
                             .onTapGesture(perform: {
-                                self.onSelected(item)
+                                delegate?.didSelectRepository(item)
                             })
                     }
                 } else {
@@ -50,9 +54,9 @@ struct SelectRepositoryView: View {
 struct SelectRepositoryView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            SelectRepositoryView(viewModel: SelectRepositoryViewModel.loading, onSelected: { _ in })
-            SelectRepositoryView(viewModel: SelectRepositoryViewModel.networkError, onSelected: { _ in })
-            SelectRepositoryView(viewModel: SelectRepositoryViewModel.someRepositories, onSelected: { _ in })
+            SelectRepositoryView(viewModel: SelectRepositoryViewModel.loading)
+            SelectRepositoryView(viewModel: SelectRepositoryViewModel.networkError)
+            SelectRepositoryView(viewModel: SelectRepositoryViewModel.someRepositories)
         }
     }
 }

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
@@ -18,7 +18,7 @@ struct SelectRepositoryView: View {
     
     // MARK: - View Model
     
-    @ObservedObject var viewModel: SelectRepositoryViewModel
+    @EnvironmentObject var viewModel: SelectRepositoryViewModel
     
     // MARK: - Private Properties
     
@@ -26,8 +26,7 @@ struct SelectRepositoryView: View {
 
     // MARK: - Initializer
     
-    init(viewModel: SelectRepositoryViewModel, delegate: SelectRepositoryDelegate? = nil) {
-        self.viewModel = viewModel
+    init(delegate: SelectRepositoryDelegate? = nil) {
         self.delegate = delegate
     }
 
@@ -62,9 +61,9 @@ struct SelectRepositoryView: View {
 struct SelectRepositoryView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            SelectRepositoryView(viewModel: SelectRepositoryViewModel.loading)
-            SelectRepositoryView(viewModel: SelectRepositoryViewModel.networkError)
-            SelectRepositoryView(viewModel: SelectRepositoryViewModel.someRepositories)
+            SelectRepositoryView().environmentObject(SelectRepositoryViewModel.loading)
+            SelectRepositoryView().environmentObject(SelectRepositoryViewModel.networkError)
+            SelectRepositoryView().environmentObject(SelectRepositoryViewModel.someRepositories)
         }
     }
 }

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
@@ -16,14 +16,22 @@ protocol SelectRepositoryDelegate: class {
 
 struct SelectRepositoryView: View {
     
+    // MARK: - View Model
+    
     @ObservedObject var viewModel: SelectRepositoryViewModel
+    
+    // MARK: - Private Properties
+    
     weak var delegate: SelectRepositoryDelegate?
 
-    init(viewModel: SelectRepositoryViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, delegate: SelectRepositoryDelegate? = nil) {
+    // MARK: - Initializer
+    
+    init(viewModel: SelectRepositoryViewModel, delegate: SelectRepositoryDelegate? = nil) {
         self.viewModel = viewModel
         self.delegate = delegate
-        self.viewModel.publisher = publisher
     }
+
+    // MARK: - View
     
     var body: some View {
         switch viewModel.state {

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
@@ -24,15 +24,7 @@ struct SelectRepositoryView: View {
     var body: some View {
         switch viewModel.state {
         case .loading:
-            List {
-                ForEach(0..<10) { _ in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text("Owner - Repository")
-                        }
-                    }
-                }
-            }.redacted(reason: .placeholder)
+            Text("Loading ...")
         case .networkError:
             Text("A network error has occurred")
         case .results(let repositories):

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
@@ -18,7 +18,7 @@ class SettingsRepositoriesFeature: BaseFeature<Dependencies> {
 
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    SettingsRepositoriesView(viewModel: viewModel)
+                                    SettingsRepositoriesView(viewModel: viewModel, delegate: self)
                                     .dependenciesToEnvironment(dependencies))
     }
 
@@ -32,10 +32,8 @@ class SettingsRepositoriesFeature: BaseFeature<Dependencies> {
 
     @objc
     func didSelectAdd(sender: Any) {
-        let selectRepository = SelectRepositoryFeature(dependencies: dependencies)
-        present(selectRepository, animated: true) {
-            
-        }
+        let selectRepository = SelectRepositoryFeature(dependencies: dependencies, delegate: self)
+        present(selectRepository, animated: true) { }
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -59,7 +57,6 @@ class SettingsRepositoriesFeature: BaseFeature<Dependencies> {
             }
         }).store(in: &self.disposables)
     }
-    
     
 //    var body: some View {
 //        SettingsRepositoriesView(viewModel: viewModel, publisher: repositoryList.fetchRepositoriesPublisher())
@@ -90,3 +87,20 @@ class SettingsRepositoriesFeature: BaseFeature<Dependencies> {
 //    }
 //}
 //#endif
+
+extension SettingsRepositoriesFeature: SettingsRepositoriesViewDelegate {
+
+    func didDeleteRepositories(_ indexSet: IndexSet) {
+        dependencies.repositoryList.removeRepositories(indexSet)
+        reloadList()
+    }
+}
+
+extension SettingsRepositoriesFeature: SelectRepositoryDelegate {
+
+    func didSelectRepository(_ repository: Repository) {
+        dependencies.repositoryList.addRepository(repository: repository)
+        dismiss(animated: true, completion: {})
+        reloadList()
+    }
+}

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
@@ -6,45 +6,87 @@
 //  Copyright © 2020 David House. All rights reserved.
 //
 
+import UIKit
 import SwiftUI
+import Combine
+import HouseKit
 
-struct SettingsRepositoriesFeature: View {
-    
-    @EnvironmentObject var repositoryList: RepositoryList
-    @State var showingSelectRepository = false
-    
-    let viewModel: SettingsRepositoriesViewModel
-
-    init(viewModel: SettingsRepositoriesViewModel? = nil) {
-        self.viewModel = viewModel ?? SettingsRepositoriesViewModel()
-    }
+class SettingsRepositoriesFeature: BaseFeature<Dependencies> {
         
-    var body: some View {
-        SettingsRepositoriesView(viewModel: viewModel, publisher: repositoryList.fetchRepositoriesPublisher())
-            .navigationBarTitle("Repositories")
-            .navigationBarItems(trailing:
-                Button("Add") {
-                    self.showingSelectRepository = true
-                }
-            )
-            .sheet(isPresented: $showingSelectRepository, content: {
-                SelectRepositoryFeature(onSelected: { repository in
-                    repositoryList.addRepository(repository: repository)
-                    viewModel.fetch()
-                    self.showingSelectRepository = false
-                })
-            })
-    }
-}
+    var publisher: AnyPublisher<[Repository], ServiceError>?
+    private var disposables = Set<AnyCancellable>()
 
-#if DEBUG
-struct SettingsRepositoriesFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                SettingsRepositoriesFeature()
-            }
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    SettingsRepositoriesView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Favorite Repositories"
+        navigationItem.largeTitleDisplayMode = .automatic
+        let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(SettingsRepositoriesFeature.didSelectAdd(sender:)))
+        navigationItem.rightBarButtonItem = addButton
+    }
+
+    @objc
+    func didSelectAdd(sender: Any) {
+        let selectRepository = SelectRepositoryFeature(dependencies: dependencies)
+        present(selectRepository, animated: true) {
+            
         }
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        reloadList()
+    }
+    
+    let viewModel = SettingsRepositoriesViewModel()
+    
+    private func reloadList() {
+        publisher = dependencies.repositoryList.fetchRepositoriesPublisher()
+        self.publisher?.sink(receiveCompletion: { result in
+          if case let .failure(error) = result {
+            print("Error receiving \(error)")
+            DispatchQueue.main.async {
+                self.viewModel.state = .networkError
+            }
+          }
+        }, receiveValue: { value in
+            DispatchQueue.main.async {
+                self.viewModel.state = .results(value)
+            }
+        }).store(in: &self.disposables)
+    }
+    
+    
+//    var body: some View {
+//        SettingsRepositoriesView(viewModel: viewModel, publisher: repositoryList.fetchRepositoriesPublisher())
+//            .navigationBarTitle("Repositories")
+//            .navigationBarItems(trailing:
+//                Button("Add") {
+//                    self.showingSelectRepository = true
+//                }
+//            )
+//            .sheet(isPresented: $showingSelectRepository, content: {
+//                SelectRepositoryFeature(onSelected: { repository in
+//                    repositoryList.addRepository(repository: repository)
+//                    viewModel.fetch()
+//                    self.showingSelectRepository = false
+//                })
+//            })
+//    }
 }
-#endif
+
+//#if DEBUG
+//struct SettingsRepositoriesFeature_Previews: PreviewProvider {
+//    static var previews: some View {
+//        DevicePreviewer {
+//            NavigationView {
+//                SettingsRepositoriesFeature()
+//            }
+//        }
+//    }
+//}
+//#endif

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
@@ -11,8 +11,14 @@ import SwiftUI
 import Combine
 import HouseKit
 
-class SettingsRepositoriesFeature: BaseFeature<Dependencies> {
+class SettingsRepositoriesFeature: BaseFeature {
 
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return SettingsRepositoriesFeature(dependencies: dependencies)
+    }
+    
     // MARK: - Private properties
     
     private var viewModel = SettingsRepositoriesViewModel()

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
@@ -27,7 +27,9 @@ class SettingsRepositoriesFeature: BaseFeature {
 
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    SettingsRepositoriesView(viewModel: viewModel, delegate: self)
+                                    SettingsRepositoriesView(delegate: self)
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
@@ -18,7 +18,7 @@ struct SettingsRepositoriesView: View {
 
     // MARK: - View Model
 
-    @ObservedObject var viewModel: SettingsRepositoriesViewModel
+    @EnvironmentObject var viewModel: SettingsRepositoriesViewModel
 
     // MARK: - Private Properties
     
@@ -26,8 +26,7 @@ struct SettingsRepositoriesView: View {
 
     // MARK: - Initializer
     
-    init(viewModel: SettingsRepositoriesViewModel, delegate: SettingsRepositoriesViewDelegate? = nil) {
-        self.viewModel = viewModel
+    init(delegate: SettingsRepositoriesViewDelegate? = nil) {
         self.delegate = delegate
     }
     
@@ -60,10 +59,10 @@ struct SettingsRepositoriesView: View {
 struct SettingsRepositoriesView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .loading))
-            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .networkError))
-            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results(Repository.someRepositories)))
-            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results([])))
+            SettingsRepositoriesView().environmentObject(SettingsRepositoriesViewModel(state: .loading))
+            SettingsRepositoriesView().environmentObject(SettingsRepositoriesViewModel(state: .networkError))
+            SettingsRepositoriesView().environmentObject(SettingsRepositoriesViewModel(state: .results(Repository.someRepositories)))
+            SettingsRepositoriesView().environmentObject(SettingsRepositoriesViewModel(state: .results([])))
         }
     }
 }

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
@@ -16,14 +16,22 @@ protocol SettingsRepositoriesViewDelegate: class {
 
 struct SettingsRepositoriesView: View {
 
-    weak var delegate: SettingsRepositoriesViewDelegate?
+    // MARK: - View Model
 
     @ObservedObject var viewModel: SettingsRepositoriesViewModel
 
-    init(viewModel: SettingsRepositoriesViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, delegate: SettingsRepositoriesViewDelegate? = nil) {
+    // MARK: - Private Properties
+    
+    private weak var delegate: SettingsRepositoriesViewDelegate?
+
+    // MARK: - Initializer
+    
+    init(viewModel: SettingsRepositoriesViewModel, delegate: SettingsRepositoriesViewDelegate? = nil) {
         self.viewModel = viewModel
         self.delegate = delegate
     }
+    
+    // MARK: - Body
     
     var body: some View {
         switch viewModel.state {
@@ -53,10 +61,9 @@ struct SettingsRepositoriesView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
             SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .loading))
+            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .networkError))
             SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results(Repository.someRepositories)))
-//            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .loading))
-//            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .networkError))
-//            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results(Repository.someRepositories)))
+            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results([])))
         }
     }
 }

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
@@ -42,7 +42,7 @@ struct SettingsRepositoriesView: View {
             List {
                 if repositories.count > 0 {
                     ForEach(repositories, id: \.self) { item in
-                        RepositoryCell(repository: item)
+                        FavoriteRepositoryCell(repository: item)
                     }.onDelete(perform: { indexSet in
                         self.delegate?.didDeleteRepositories(indexSet)
                     })

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
@@ -10,12 +10,19 @@ import SwiftUI
 import HouseKit
 import Combine
 
+protocol SettingsRepositoriesViewDelegate: class {
+    func didDeleteRepositories(_ indexSet: IndexSet)
+}
+
 struct SettingsRepositoriesView: View {
-    
+
+    weak var delegate: SettingsRepositoriesViewDelegate?
+
     @ObservedObject var viewModel: SettingsRepositoriesViewModel
 
-    init(viewModel: SettingsRepositoriesViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil) {
+    init(viewModel: SettingsRepositoriesViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil, delegate: SettingsRepositoriesViewDelegate? = nil) {
         self.viewModel = viewModel
+        self.delegate = delegate
     }
     
     var body: some View {
@@ -29,7 +36,9 @@ struct SettingsRepositoriesView: View {
                 if repositories.count > 0 {
                     ForEach(repositories, id: \.self) { item in
                         RepositoryCell(repository: item)
-                    }
+                    }.onDelete(perform: { indexSet in
+                        self.delegate?.didDeleteRepositories(indexSet)
+                    })
                 } else {
                     Text("No repositories selected")
                 }

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
@@ -16,21 +16,12 @@ struct SettingsRepositoriesView: View {
 
     init(viewModel: SettingsRepositoriesViewModel, publisher: AnyPublisher<[Repository], ServiceError>? = nil) {
         self.viewModel = viewModel
-        self.viewModel.publisher = publisher
     }
     
     var body: some View {
         switch viewModel.state {
         case .loading:
-            List {
-                ForEach(0..<10) { _ in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text("Owner - Repository")
-                        }
-                    }
-                }
-            }.redacted(reason: .placeholder)
+            Text("Loading...")
         case .networkError:
             Text("A network error has occurred")
         case .results(let repositories):
@@ -53,8 +44,10 @@ struct SettingsRepositoriesView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
             SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .loading))
-            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .networkError))
             SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results(Repository.someRepositories)))
+//            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .loading))
+//            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .networkError))
+//            SettingsRepositoriesView(viewModel: SettingsRepositoriesViewModel(state: .results(Repository.someRepositories)))
         }
     }
 }

--- a/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerFeature.swift
+++ b/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerFeature.swift
@@ -8,8 +8,14 @@
 import UIKit
 import SwiftUI
 
-class SettingsStampedeServerFeature: BaseFeature<Dependencies> {
+class SettingsStampedeServerFeature: BaseFeature {
 
+    // MARK: - Static methods
+    
+    static func makeFeature(_ dependencies: Dependencies) -> BaseFeature {
+        return SettingsStampedeServerFeature(dependencies: dependencies)
+    }
+    
     // MARK: - Private Properties
     
     private var viewModel = SettingsStampedeServerViewModel()

--- a/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerFeature.swift
+++ b/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerFeature.swift
@@ -5,33 +5,33 @@
 //  Created by David House on 7/11/20.
 //  Copyright © 2020 David House. All rights reserved.
 //
-
+import UIKit
 import SwiftUI
 
-struct SettingsStampedeServerFeature: View {
+class SettingsStampedeServerFeature: BaseFeature<Dependencies> {
 
-    // MARK: - Environment
-
-    @EnvironmentObject var service: StampedeService
-    @EnvironmentObject var defaults: StampedeDefaults
-
-    // MARK: - View
-
-    var body: some View {
-        SettingsStampedeServerView(viewModel: SettingsStampedeServerViewModel(stampedeServerURL: defaults.host ?? "", subject: service.hostPassthroughSubject))
-            .navigationBarTitle("Stampede Server")
+    // MARK: - Private Properties
+    
+    private var viewModel = SettingsStampedeServerViewModel()
+    
+    // MARK: - Overrides
+    
+    override func makeChildViewController() -> UIViewController {
+        return UIHostingController(rootView:
+                                    SettingsStampedeServerView(viewModel: viewModel)
+                                    .dependenciesToEnvironment(dependencies))
+    }
+    
+    // MARK: - View Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Stampede Server"
+        navigationItem.largeTitleDisplayMode = .automatic
     }
 
-}
-
-#if DEBUG
-struct SettingsStampedeServerFeature_Previews: PreviewProvider {
-    static var previews: some View {
-        DevicePreviewer {
-            NavigationView {
-                SettingsStampedeServerFeature()
-            }
-        }
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.stampedeServerURL = dependencies.defaults.host ?? ""
+        viewModel.subject = dependencies.service.hostPassthroughSubject
     }
 }
-#endif

--- a/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerFeature.swift
+++ b/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerFeature.swift
@@ -24,7 +24,9 @@ class SettingsStampedeServerFeature: BaseFeature {
     
     override func makeChildViewController() -> UIViewController {
         return UIHostingController(rootView:
-                                    SettingsStampedeServerView(viewModel: viewModel)
+                                    SettingsStampedeServerView()
+                                    .environmentObject(viewModel)
+                                    .environmentObject(router)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerView.swift
+++ b/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerView.swift
@@ -14,7 +14,7 @@ struct SettingsStampedeServerView: View {
 
     // MARK: - Observed Objects
 
-    @ObservedObject var viewModel: SettingsStampedeServerViewModel
+    @EnvironmentObject var viewModel: SettingsStampedeServerViewModel
 
     // MARK: - View
 
@@ -34,8 +34,8 @@ struct SettingsStampedeServerView: View {
 struct SettingsStampedeServerView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            SettingsStampedeServerView(viewModel: SettingsStampedeServerViewModel.someViewModel)
-            SettingsStampedeServerView(viewModel: SettingsStampedeServerViewModel.someViewModelWithNoHost).environmentObject(StampedeDefaults.defaultsWithNoHost)
+            SettingsStampedeServerView().environmentObject(SettingsStampedeServerViewModel.someViewModel)
+            SettingsStampedeServerView().environmentObject(SettingsStampedeServerViewModel.someViewModelWithNoHost).environmentObject(StampedeDefaults.defaultsWithNoHost)
         }
 
     }

--- a/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerViewModel.swift
+++ b/Stampede/Stampede/Features/Settings/StampedeServer/SettingsStampedeServerViewModel.swift
@@ -23,7 +23,7 @@ class SettingsStampedeServerViewModel: ObservableObject {
 
     // MARK: - Properties
 
-    let subject: PassthroughSubject<String, Never>?
+    var subject: PassthroughSubject<String, Never>?
 
     // MARK: - Initializer
 

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -20,37 +20,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
 
             if !areTestsRunning() && !arePreviewsRunning() {
-                let defaults: StampedeDefaults = {
-                    return StampedeDefaults()
-                }()
-
-                let repositoryList: RepositoryList = {
-                    #if DEBUG
-                    if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"], stampedeServer == "fixtures" {
-                            return RepositoryList(repositories: [Repository.someRepository])
-                    }
-                    #endif
-                    return RepositoryList()
-                }()
-                
-                let service: StampedeService = {
-                    #if DEBUG
-                    if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"] {
-                        if stampedeServer == "fixtures" {
-                            return StampedeService(host: stampedeServer, provider: StampedeServiceFixtureProvider())
-                        } else {
-                            return StampedeService(host: stampedeServer, provider: StampedeServiceNetworkProvider(host: stampedeServer))
-                        }
-                    } else {
-                        return StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
-                    }
-                    #else
-                    return StampedeService(host: defaults.host, provider: StampedeServiceNetworkProvider(host: defaults.host))
-                    #endif
-                }()
-                defaults.hostSubject = service.hostPassthroughSubject
-
-                let theme = CurrentTheme()
                 let dependencies = Dependencies()
 
                 let rootNavVC = MainNavigationController(rootViewController: MainFeature(dependencies: dependencies))

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -24,15 +24,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
                 let rootNavVC = MainNavigationController(rootViewController: MainFeature(dependencies: dependencies))
                 window.rootViewController = rootNavVC
-
-//                window.rootViewController = UIHostingController(rootView: MainFeature()
-//                    .environmentObject(service)
-//                    .environmentObject(defaults)
-//                    .environmentObject(theme)
-//                    .environmentObject(repositoryList)
-                //)
             } else {
-                window.rootViewController = UIHostingController(rootView: EmptyView())
+                window.rootViewController = UIViewController()
             }
             self.window = window
             window.makeKeyAndVisible()

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -20,7 +20,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
 
             if !areTestsRunning() && !arePreviewsRunning() {
-                let dependencies = Dependencies()
+                
+                let dependencies: Dependencies = {
+                    if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"], stampedeServer == "fixtures" {
+                        return FixtureDependencies()
+                    } else {
+                        return BaseDependencies()
+                    }
+                }()
 
                 let rootNavVC = MainNavigationController(rootViewController: MainFeature(dependencies: dependencies))
                 window.rootViewController = rootNavVC

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -51,13 +51,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 defaults.hostSubject = service.hostPassthroughSubject
 
                 let theme = CurrentTheme()
+                let dependencies = Dependencies()
 
-                window.rootViewController = UIHostingController(rootView: MainFeature()
-                    .environmentObject(service)
-                    .environmentObject(defaults)
-                    .environmentObject(theme)
-                    .environmentObject(repositoryList)
-                )
+                let rootNavVC = MainNavigationController(rootViewController: MainFeature(dependencies: dependencies))
+                window.rootViewController = rootNavVC
+
+//                window.rootViewController = UIHostingController(rootView: MainFeature()
+//                    .environmentObject(service)
+//                    .environmentObject(defaults)
+//                    .environmentObject(theme)
+//                    .environmentObject(repositoryList)
+                //)
             } else {
                 window.rootViewController = UIHostingController(rootView: EmptyView())
             }

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -23,9 +23,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 
                 let dependencies: Dependencies = {
                     if let stampedeServer = ProcessInfo.processInfo.environment["StampedeServer"], stampedeServer == "fixtures" {
-                        return FixtureDependencies()
+                        return Dependencies(repositoryList: RepositoryListFixture())
                     } else {
-                        return BaseDependencies()
+                        return Dependencies()
                     }
                 }()
 


### PR DESCRIPTION
This PR changes the Feature level of the code to use View Controllers instead of SwiftUI views. This moves the navigation responsibility to the View Controllers, and the end-result code is very clean.
