### PR TITLE
♻️ Use network error view

### DIFF
--- a/Stampede/Stampede.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Stampede/Stampede.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/davidahouse/HouseKit",
         "state": {
           "branch": "main",
-          "revision": "d3787337b5fb943402e64fb901ac9710e07bab62",
+          "revision": "3add5db05f47fa893aec25428eaa7edd5e6e70f9",
           "version": null
         }
       }

--- a/Stampede/Stampede/Common/BaseSubView.swift
+++ b/Stampede/Stampede/Common/BaseSubView.swift
@@ -23,7 +23,7 @@ struct BaseSubView<T, Content: View>: View {
         case .loading:
             Text("Loading...")
         case .networkError:
-            Text("Network error...")
+            NetworkErrorView()
         case .results(let object):
             content(object)
         }

--- a/Stampede/Stampede/Common/BaseView.swift
+++ b/Stampede/Stampede/Common/BaseView.swift
@@ -23,7 +23,7 @@ struct BaseView<T, Content: View>: View {
         case .loading:
             Text("Loading...")
         case .networkError:
-            Text("Network error...")
+            NetworkErrorView()
         case .results(let object):
             content(object)
         }

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
@@ -43,7 +43,24 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     var fetchBuildKeysPublisherCalled = false
 
     var hostPassthroughSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
-    
+
+    private var host: String? {
+        didSet {
+            if let host = host, host.contains("error") {
+                self.error = .network(description: "some network error happened")
+            }
+        }
+    }
+    private var hostSink: AnyCancellable?
+
+    public init(host: String? = nil) {
+        self.host = host
+        super.init()
+        hostSink = hostPassthroughSubject.sink(receiveValue: { value in
+           self.host = value
+        })
+    }
+
     func fetchRepositoriesPublisher() -> AnyPublisher<[Repository], ServiceError>? {
         fetchRepositoriesPublisherCalled = true
         return fetchPublisher(repositories)

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
@@ -26,7 +26,7 @@ struct MonitorLiveView: View {
         case .loading:
             Text("Loading...")
         case .networkError:
-            Text("Network Error...")
+            NetworkErrorView()
         case .results(let results):
 //            ScrollView {
 //                LazyVGrid(columns: columns) {


### PR DESCRIPTION
This PR updates the error states in the UI to all use the common NetworkErrorView. Now all error cases should have exactly the same UI.

closes #24 