### PR TITLE
✨Added deep linking to build details

### DIFF
--- a/Stampede/Stampede-Tests/Features/Build/BuildViewModelTests.swift
+++ b/Stampede/Stampede-Tests/Features/Build/BuildViewModelTests.swift
@@ -19,7 +19,7 @@ class BuildViewModelTests: XCTestCase {
             BuildStatus.someRecentFailedBuild
         ]
         for status in buildStatuses {
-            let viewModel = BuildViewModel(buildStatus: status)
+            let viewModel = BuildViewModel(state: .results(status))
             _ = viewModel.statusImage
         }
     }

--- a/Stampede/Stampede/AppDelegate.swift
+++ b/Stampede/Stampede/AppDelegate.swift
@@ -15,7 +15,43 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
-
+//
+//    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
+//        // Get URL components from the incoming user activity.
+//        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+//            let incomingURL = userActivity.webpageURL,
+//            let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
+//            return false
+//        }
+//
+//        // Check for specific URL components that you need.
+//        guard let path = components.path,
+//        let params = components.queryItems else {
+//            return false
+//        }
+//        print("path = \(path)")
+//        print("params = \(params)")
+//        return false
+//    }
+//
+//    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+//        // Determine who sent the URL.
+//            let sendingAppID = options[.sourceApplication]
+//            print("source application = \(sendingAppID ?? "Unknown")")
+//
+//            // Process the URL.
+//            guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
+//                let path = components.path,
+//                let params = components.queryItems else {
+//                    print("Invalid URL or album path missing")
+//                    return false
+//            }
+//
+//        print("path = \(path)")
+//        print("params = \(params)")
+//        return true
+//    }
+    
     // MARK: UISceneSession Lifecycle
 
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {

--- a/Stampede/Stampede/AppDelegate.swift
+++ b/Stampede/Stampede/AppDelegate.swift
@@ -15,42 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
-//
-//    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-//        // Get URL components from the incoming user activity.
-//        guard userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-//            let incomingURL = userActivity.webpageURL,
-//            let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) else {
-//            return false
-//        }
-//
-//        // Check for specific URL components that you need.
-//        guard let path = components.path,
-//        let params = components.queryItems else {
-//            return false
-//        }
-//        print("path = \(path)")
-//        print("params = \(params)")
-//        return false
-//    }
-//
-//    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-//        // Determine who sent the URL.
-//            let sendingAppID = options[.sourceApplication]
-//            print("source application = \(sendingAppID ?? "Unknown")")
-//
-//            // Process the URL.
-//            guard let components = NSURLComponents(url: url, resolvingAgainstBaseURL: true),
-//                let path = components.path,
-//                let params = components.queryItems else {
-//                    print("Invalid URL or album path missing")
-//                    return false
-//            }
-//
-//        print("path = \(path)")
-//        print("params = \(params)")
-//        return true
-//    }
     
     // MARK: UISceneSession Lifecycle
 

--- a/Stampede/Stampede/Common/Route.swift
+++ b/Stampede/Stampede/Common/Route.swift
@@ -67,4 +67,18 @@ enum Route {
             return SettingsInfoFeature.makeFeature(dependencies)
         }
     }
+    
+    static func fromURL(_ url: URL) -> Route? {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        switch url.path {
+        case "/build":
+            if let buildID = components?.queryItems?.filter({ $0.name == "buildID" }).first {
+                return nil
+            } else {
+                return nil
+            }
+        default:
+            return nil
+        }
+    }
 }

--- a/Stampede/Stampede/Common/Route.swift
+++ b/Stampede/Stampede/Common/Route.swift
@@ -19,6 +19,7 @@ enum Route {
     // Repository and Builds
     case repositoryDetails(_ repository: Repository)
     case buildDetails(_ buildStatus: BuildStatus)
+    case buildDetailsFromID(_ buildID: String)
     case taskDetails(_ task: TaskStatus)
     
     // Monitor
@@ -43,6 +44,8 @@ enum Route {
             return RepositoryFeature.makeFeature(dependencies, repository: repository)
         case .buildDetails(let buildStatus):
             return BuildFeature.makeFeature(dependencies, build: buildStatus)
+        case .buildDetailsFromID(let buildID):
+            return BuildFeature.makeFeature(dependencies, buildID: buildID)
         case .taskDetails(let task):
             return BuildTaskFeature.makeFeature(dependencies, task: task)
         case .monitorLive:
@@ -72,8 +75,8 @@ enum Route {
         let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         switch url.path {
         case "/build":
-            if let buildID = components?.queryItems?.filter({ $0.name == "buildID" }).first {
-                return nil
+            if let buildIDQueryItem = components?.queryItems?.filter({ $0.name == "buildID" }).first, let buildID = buildIDQueryItem.value {
+                return .buildDetailsFromID(buildID)
             } else {
                 return nil
             }

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeAPIEndpoint.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeAPIEndpoint.swift
@@ -9,16 +9,21 @@
 import Foundation
 
 public enum StampedeAPIEndpoint {
+    // Repository
     case repositories
     case activeBuilds(String, String)
     case repositoryBuilds(String, String)
     case buildKeys(String, String, String)
+    case buildDetails(String)
+    // Monitor
     case monitorActiveBuilds
     case monitorActiveTasks
     case monitorWorkerStatus
     case monitorQueues
+    // History
     case historyTasks
     case historyHourlySummary
+    // Admin
     case adminTasks
     case adminConfigDefaults
     case adminConfigOverrides
@@ -34,6 +39,8 @@ public enum StampedeAPIEndpoint {
             return URL(string: "\(host)/api/repository/repositoryBuilds?owner=\(owner)&repository=\(repository)")!
         case let .buildKeys(owner, repository, source):
             return URL(string: "\(host)/api/repository/buildKeys?owner=\(owner)&repository=\(repository)&source=\(source)")!
+        case let .buildDetails(buildID):
+            return URL(string: "\(host)/api/repository/buildDetails?buildID=\(buildID)")!
         case .monitorActiveBuilds:
             return URL(string: "\(host)/api/monitor/activeBuilds")!
         case .monitorActiveTasks:

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeService.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeService.swift
@@ -37,6 +37,10 @@ public class StampedeService: ObservableObject {
     public func fetchBuildKeysPublisher(owner: String, repository: String, source: String) -> AnyPublisher<[BuildKey], ServiceError>? {
         return provider.fetchBuildKeysPublisher(owner: owner, repository: repository, source: source)
     }
+    
+    public func fetchBuildDetailsPublisher(buildID: String) -> AnyPublisher<BuildStatus, ServiceError>? {
+        return provider.fetchBuildDetailsPublisher(buildID: buildID)
+    }
 
     public func fetchAdminTasksPublisher() -> AnyPublisher<[Task], ServiceError>? {
         return provider.fetchAdminTasksPublisher()

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
@@ -27,6 +27,7 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     var configOverrides = ConfigOverrides.someOverrides
     var configQueues = Queue.someQueues
     var buildKeys = BuildKey.someBranchKeys
+    var buildDetails = BuildStatus.buildCompletedHoursAgo
 
     var fetchRepositoriesPublisherCalled = false
     var fetchActiveBuildsPublisherCalled = false
@@ -41,6 +42,7 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     var fetchAdminConfigOverridesPublisherCalled = false
     var fetchAdminQueuesPublisherCalled = false
     var fetchBuildKeysPublisherCalled = false
+    var fetchBuildDetailsPublisherCalled = false
 
     var hostPassthroughSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
 
@@ -74,6 +76,11 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     func fetchRepositoryBuildsPublisher(owner: String, repository: String) -> AnyPublisher<[RepositoryBuild], ServiceError>? {
         fetchRepositoryBuildsPublisherCalled = true
         return fetchPublisher(repositoryBuilds)
+    }
+    
+    func fetchBuildDetailsPublisher(buildID: String) -> AnyPublisher<BuildStatus, ServiceError>? {
+        fetchBuildDetailsPublisherCalled = true
+        return fetchPublisher(buildDetails)
     }
     
     func fetchActiveBuildsPublisher() -> AnyPublisher<[BuildStatus], ServiceError>? {

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceNetworkProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceNetworkProvider.swift
@@ -45,6 +45,13 @@ public class StampedeServiceNetworkProvider: NetworkProvider, StampedeServicePro
         }
         return request(url: StampedeAPIEndpoint.repositoryBuilds(owner, repository).url(host: host))
     }
+    
+    public func fetchBuildDetailsPublisher(buildID: String) -> AnyPublisher<BuildStatus, ServiceError>? {
+        guard let host = host else {
+            return AnyPublisher<BuildStatus, ServiceError>(Future<BuildStatus, ServiceError> { promise in promise(.failure(.network(description: "Host not provided")))})
+        }
+        return request(url: StampedeAPIEndpoint.buildDetails(buildID).url(host: host))
+    }
 
     public func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>? {
         guard let host = host else {

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceProvider.swift
@@ -20,6 +20,7 @@ public protocol StampedeServiceProvider {
     func fetchActiveBuildsPublisher(owner: String, repository: String) -> AnyPublisher<[BuildStatus], ServiceError>?
     func fetchRepositoryBuildsPublisher(owner: String, repository: String) -> AnyPublisher<[RepositoryBuild], ServiceError>?
     func fetchBuildKeysPublisher(owner: String, repository: String, source: String) -> AnyPublisher<[BuildKey], ServiceError>?
+    func fetchBuildDetailsPublisher(buildID: String) -> AnyPublisher<BuildStatus, ServiceError>?
 
     // Monitor
     func fetchActiveBuildsPublisher() -> AnyPublisher<[BuildStatus], ServiceError>?

--- a/Stampede/Stampede/Features/Build/BuildFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildFeature.swift
@@ -16,9 +16,14 @@ class BuildFeature: BaseFeature {
         return BuildFeature(dependencies: dependencies, buildStatus: build)
     }
     
+    static func makeFeature(_ dependencies: Dependencies, buildID: String) -> BaseFeature {
+        return BuildFeature(dependencies: dependencies, buildID: buildID)
+    }
+    
     // MARK: - Private Properties
     
     private var viewModel: BuildViewModel
+    private var buildID: String?
 
     // MARK: - Overrides
     
@@ -33,8 +38,16 @@ class BuildFeature: BaseFeature {
     // MARK: - Initializer
     
     init(dependencies: Dependencies, buildStatus: BuildStatus) {
-        viewModel = BuildViewModel(buildStatus: buildStatus)
+        viewModel = BuildViewModel(state: .results(buildStatus))
         super.init(dependencies: dependencies)
+        title = buildStatus.buildIdentifier
+    }
+    
+    init(dependencies: Dependencies, buildID: String) {
+        viewModel = BuildViewModel(state: .loading)
+        self.buildID = buildID
+        super.init(dependencies: dependencies)
+        title = buildID
     }
     
     required init?(coder: NSCoder) {
@@ -45,7 +58,12 @@ class BuildFeature: BaseFeature {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = viewModel.buildStatus.buildIdentifier
         navigationItem.largeTitleDisplayMode = .automatic
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        if let buildID = buildID {
+            viewModel.publisher = dependencies.service.fetchBuildDetailsPublisher(buildID: buildID)
+        }
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildView.swift
+++ b/Stampede/Stampede/Features/Build/BuildView.swift
@@ -18,18 +18,19 @@ struct BuildView: View {
     // MARK: - View
 
     var body: some View {
-        List {
+        BaseView(viewModel: viewModel, content: { buildStatus in
+            List {
                 Section(header: Text("Build Details")) {
                     HStack {
                         Text("Owner")
                         Spacer()
-                        Text(viewModel.buildStatus.buildDetails.owner)
+                        Text(buildStatus.buildDetails.owner)
                     }
 
                     HStack {
                         Text("Repository")
                         Spacer()
-                        Text(viewModel.buildStatus.buildDetails.repository)
+                        Text(buildStatus.buildDetails.repository)
                     }
 
                     HStack {
@@ -41,10 +42,10 @@ struct BuildView: View {
                     HStack {
                         Text("Started At")
                         Spacer()
-                        PrimaryLabel("\(viewModel.buildStatus.buildDetails.started_at)")
+                        PrimaryLabel("\(buildStatus.buildDetails.started_at)")
                     }
 
-                    if let completed_at = viewModel.buildStatus.buildDetails.completed_at {
+                    if let completed_at = buildStatus.buildDetails.completed_at {
                         HStack {
                             Text("Completed At")
                             Spacer()
@@ -60,7 +61,7 @@ struct BuildView: View {
                 }
 
                 Section(header: Text("Tasks")) {
-                    ForEach(viewModel.buildStatus.tasks) { task in
+                    ForEach(buildStatus.tasks) { task in
                         Button(action: {
                             router.route(to: .taskDetails(task))
                         }, label: {
@@ -68,7 +69,8 @@ struct BuildView: View {
                         })
                     }
                 }
-        }
+            }
+        })
     }
 }
 
@@ -76,8 +78,8 @@ struct BuildView: View {
 struct BuildView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            BuildView().environmentObject(BuildViewModel(buildStatus: BuildStatus.someActiveBuild))
-            BuildView().environmentObject(BuildViewModel(buildStatus: BuildStatus.someRecentSuccessBuild))
+            BuildView().environmentObject(BuildViewModel(state: .results(BuildStatus.someActiveBuild)))
+            BuildView().environmentObject(BuildViewModel(state: .results(BuildStatus.someRecentSuccessBuild)))
         }
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildViewModel.swift
+++ b/Stampede/Stampede/Features/Build/BuildViewModel.swift
@@ -9,20 +9,23 @@
 import Foundation
 import SwiftUI
 
-class BuildViewModel: ObservableObject {
+class BuildViewModel: BaseViewModel<BuildStatus> { } {
 
     // MARK: - Published
-
-    @Published var buildStatus: BuildStatus
     
     var statusImage: some View {
-        switch buildStatus.statusIndicator {
-        case .inProgress:
-            return CurrentTheme.Icons.inProgress.image()
-        case .failure:
-            return CurrentTheme.Icons.failure.image()
-        case .success:
-            return CurrentTheme.Icons.success.image()
+        switch state {
+        case .results(let buildStatus):
+            switch buildStatus.statusIndicator {
+            case .inProgress:
+                return CurrentTheme.Icons.inProgress.image()
+            case .failure:
+                return CurrentTheme.Icons.failure.image()
+            case .success:
+                return CurrentTheme.Icons.success.image()
+            }
+        default:
+            return CurrentTheme.Icons.warningStatus.image()
         }
     }
 

--- a/Stampede/Stampede/Features/Build/BuildViewModel.swift
+++ b/Stampede/Stampede/Features/Build/BuildViewModel.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 import SwiftUI
+import HouseKit
 
-class BuildViewModel: BaseViewModel<BuildStatus> { } {
+class BuildViewModel: BaseViewModel<BuildStatus> {
 
     // MARK: - Published
     
@@ -27,11 +28,5 @@ class BuildViewModel: BaseViewModel<BuildStatus> { } {
         default:
             return CurrentTheme.Icons.warningStatus.image()
         }
-    }
-
-    // MARK: - Initializer
-
-    init(buildStatus: BuildStatus) {
-        self.buildStatus = buildStatus
     }
 }

--- a/Stampede/Stampede/Info.plist
+++ b/Stampede/Stampede/Info.plist
@@ -16,6 +16,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>CFBundleURLName</key>
+			<string>com.davidahouse.stampede</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stampede</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -56,7 +56,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             self.window = window
             window.makeKeyAndVisible()
         }
-
     }
     
     /**

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -12,9 +12,27 @@ import SwiftUI
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    var mainFeature: MainFeature?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
+        if let userActivity = connectionOptions.userActivities.first,
+               userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+               let incomingURL = userActivity.webpageURL,
+               let components = NSURLComponents(url: incomingURL, resolvingAgainstBaseURL: true) {
+           
+            // Handle this link!
+            
+            // Check for specific URL components that you need.
+           guard let path = components.path,
+               let params = components.queryItems else {
+               return
+           }
+           print("scene path = \(path)")
+           print("scene params = \(params)")
+            return
+        }
+        
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
@@ -29,7 +47,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     }
                 }()
 
-                let rootNavVC = MainNavigationController(rootViewController: MainFeature(dependencies: dependencies))
+                mainFeature = MainFeature(dependencies: dependencies)
+                let rootNavVC = MainNavigationController(rootViewController: mainFeature!)
                 window.rootViewController = rootNavVC
             } else {
                 window.rootViewController = UIViewController()
@@ -40,6 +59,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     }
 
+    func scene(_ scene: UIScene, willContinueUserActivityWithType userActivityType: String) {
+        
+        print("willContinue")
+    }
+    
+    /**
+     This method is called if the app is already running and we want to deep link into it.
+     */
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        
+        print("open URL contexts!")
+        
+        if let first = URLContexts.first {
+            
+            
+            
+            
+        }
+    }
+    
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -58,24 +58,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         }
 
     }
-
-    func scene(_ scene: UIScene, willContinueUserActivityWithType userActivityType: String) {
-        
-        print("willContinue")
-    }
     
     /**
      This method is called if the app is already running and we want to deep link into it.
      */
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        
-        print("open URL contexts!")
-        
         if let first = URLContexts.first {
-            
-            
-            
-            
         }
     }
     

--- a/Stampede/Stampede/SceneDelegate.swift
+++ b/Stampede/Stampede/SceneDelegate.swift
@@ -63,7 +63,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
      This method is called if the app is already running and we want to deep link into it.
      */
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        if let first = URLContexts.first {
+        if let first = URLContexts.first, let route = Route.fromURL(first.url) {
+            mainFeature?.push(route: route)
         }
     }
     

--- a/Stampede/Stampede/Stampede.entitlements
+++ b/Stampede/Stampede/Stampede.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>stampede:www.stampedeci.com</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/Stampede/Stampede/Stampede.entitlements
+++ b/Stampede/Stampede/Stampede.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>stampede:www.stampedeci.com</string>
+		<string>stampede:stampedeci.com</string>
 	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>


### PR DESCRIPTION
This PR allows for deep linking into build details using the `stampede:` app scheme. Will add more links in the future, but for now it can link to the following URL:
`stampede://repositories/build?buildID=davidahouse-stampede-server-v1.5.0-116`

closes #26 