### PR TITLE
♻️ Task details screen now shows more detail

### DIFF
--- a/Stampede/Stampede-UITests/Main/ScenarioMainScreen+Extension.swift
+++ b/Stampede/Stampede-UITests/Main/ScenarioMainScreen+Extension.swift
@@ -17,11 +17,19 @@ extension ScenarioMainScreen {
     }
 
     func andTheRepositoriesSectionIsVisible() {
-        waitForButton("REPOSITORIES")
+        waitForStaticText("REPOSITORIES")
     }
 
     func andTheMonitorSectionIsVisible() {
-        waitForButton("MONITOR")
+        waitForStaticText("MONITOR")
+    }
+
+    func andTheHistorySectionIsVisible() {
+        waitForStaticText("HISTORY")
+    }
+
+    func andTheSettingsSectionIsVisible() {
+        waitForStaticText("SETTINGS")
     }
 
     // THEN ACCESSORS

--- a/Stampede/Stampede-UITests/Main/ScenarioMainScreen.swift
+++ b/Stampede/Stampede-UITests/Main/ScenarioMainScreen.swift
@@ -43,37 +43,37 @@ class ScenarioMainScreen: BDDTestCase {
 
     func testMainScreenContainsRouteToHistoryBuildsScreen() throws {
         givenTheMainScreenIsDisplayed()
-        andTheMonitorSectionIsVisible()
+        andTheHistorySectionIsVisible()
         thenTheHistoryBuildsButtonIsDisplayed()
     }
 
     func testMainScreenContainsRouteToHistoryTasksScreen() throws {
         givenTheMainScreenIsDisplayed()
-        andTheMonitorSectionIsVisible()
+        andTheHistorySectionIsVisible()
         thenTheHistoryTasksButtonIsDisplayed()
     }
 
     func testMainScreenContainsRouteToSettingsStampedeServerScreen() throws {
         givenTheMainScreenIsDisplayed()
-        andTheMonitorSectionIsVisible()
+        andTheSettingsSectionIsVisible()
         thenTheSettingsStampedeServerButtonIsDisplayed()
     }
 
     func testMainScreenContainsRouteToSettingsRepositoriesScreen() throws {
         givenTheMainScreenIsDisplayed()
-        andTheMonitorSectionIsVisible()
+        andTheSettingsSectionIsVisible()
         thenTheSettingsRepositoriesButtonIsDisplayed()
     }
 
     func testMainScreenContainsRouteToSettingsNotificationsScreen() throws {
         givenTheMainScreenIsDisplayed()
-        andTheMonitorSectionIsVisible()
+        andTheSettingsSectionIsVisible()
         thenTheSettigsNotificationsButtonIsDisplayed()
     }
 
     func testMainScreenContainsRouteToSettingsInfoScreen() throws {
         givenTheMainScreenIsDisplayed()
-        andTheMonitorSectionIsVisible()
+        andTheSettingsSectionIsVisible()
         thenTheSettingsInfoButtonIsDisplayed()
     }
 }

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -125,6 +125,9 @@
 		C3AD03A924885D4600EB881F /* MonitorLiveFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD03A824885D4600EB881F /* MonitorLiveFeature.swift */; };
 		C3AD03AB24885E4300EB881F /* MonitorLiveViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD03AA24885E4300EB881F /* MonitorLiveViewModel.swift */; };
 		C3AD03AD24887C4200EB881F /* QueueGaugeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AD03AC24887C4200EB881F /* QueueGaugeView.swift */; };
+		C3B1225E253B5E7C005FD154 /* TaskDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B1225D253B5E7C005FD154 /* TaskDetails.swift */; };
+		C3B12263253B5FD2005FD154 /* TaskSCMDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B12262253B5FD2005FD154 /* TaskSCMDetails.swift */; };
+		C3B12268253B600E005FD154 /* TaskArtifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B12267253B600E005FD154 /* TaskArtifact.swift */; };
 		C3B1D62B23AE8598002CCE66 /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B1D62A23AE8598002CCE66 /* XCTestCase+Extension.swift */; };
 		C3CA2E0C24BA9EA10086B71D /* HistoryBuildsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CA2E0B24BA9EA10086B71D /* HistoryBuildsFeature.swift */; };
 		C3CA2E0E24BA9EB50086B71D /* HistoryBuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CA2E0D24BA9EB50086B71D /* HistoryBuildsView.swift */; };
@@ -318,6 +321,9 @@
 		C3AD03A824885D4600EB881F /* MonitorLiveFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorLiveFeature.swift; sourceTree = "<group>"; };
 		C3AD03AA24885E4300EB881F /* MonitorLiveViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorLiveViewModel.swift; sourceTree = "<group>"; };
 		C3AD03AC24887C4200EB881F /* QueueGaugeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueGaugeView.swift; sourceTree = "<group>"; };
+		C3B1225D253B5E7C005FD154 /* TaskDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskDetails.swift; sourceTree = "<group>"; };
+		C3B12262253B5FD2005FD154 /* TaskSCMDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskSCMDetails.swift; sourceTree = "<group>"; };
+		C3B12267253B600E005FD154 /* TaskArtifact.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskArtifact.swift; sourceTree = "<group>"; };
 		C3B1D62A23AE8598002CCE66 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
 		C3CA2E0B24BA9EA10086B71D /* HistoryBuildsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryBuildsFeature.swift; sourceTree = "<group>"; };
 		C3CA2E0D24BA9EB50086B71D /* HistoryBuildsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryBuildsView.swift; sourceTree = "<group>"; };
@@ -571,6 +577,9 @@
 				94B571E124BBBECD00CA13A4 /* BuildStatus.swift */,
 				94B571E224BBBECD00CA13A4 /* Task.swift */,
 				9421332D24C33F820043FBD2 /* BuildKey.swift */,
+				C3B1225D253B5E7C005FD154 /* TaskDetails.swift */,
+				C3B12262253B5FD2005FD154 /* TaskSCMDetails.swift */,
+				C3B12267253B600E005FD154 /* TaskArtifact.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1339,6 +1348,7 @@
 				C34755F024FC88E2009B1FBF /* QueueSummaryCell.swift in Sources */,
 				94B571F724BBBECD00CA13A4 /* Task.swift in Sources */,
 				C35D51B02353C5DF00FDA4A8 /* MainView.swift in Sources */,
+				C3B1225E253B5E7C005FD154 /* TaskDetails.swift in Sources */,
 				C38C888224BA152D00F6E6C9 /* SettingsStampedeServerFeature.swift in Sources */,
 				94B571F124BBBECD00CA13A4 /* RepositoryBuild.swift in Sources */,
 				C3081AC824563CBE000C20F1 /* RepositoryFeature.swift in Sources */,
@@ -1366,6 +1376,7 @@
 				944EF65724FD1A8300357E9E /* StampedeServiceFixtureProvider.swift in Sources */,
 				94B571EE24BBBECD00CA13A4 /* ConfigOverrides.swift in Sources */,
 				C38C888624BA155A00F6E6C9 /* SettingsStampedeServerViewModel.swift in Sources */,
+				C3B12268253B600E005FD154 /* TaskArtifact.swift in Sources */,
 				C38C888424BA154B00F6E6C9 /* SettingsStampedeServerView.swift in Sources */,
 				C3CA2E1024BA9EC00086B71D /* HistoryBuildsViewModel.swift in Sources */,
 				C3F76681245B0F300022E485 /* StampedeDefaults.swift in Sources */,
@@ -1400,6 +1411,7 @@
 				94B571FE24BBBECD00CA13A4 /* StampedeService.swift in Sources */,
 				94E913AE24BB512B0056A150 /* BuildTaskViewModel.swift in Sources */,
 				C3126DA223BED33400AC542F /* SecondaryLabel.swift in Sources */,
+				C3B12263253B5FD2005FD154 /* TaskSCMDetails.swift in Sources */,
 				C3CA2E2224BA9F600086B71D /* SettingsNotificationsView.swift in Sources */,
 				C3816C80248702AB00E6980B /* MonitorActiveTasksFeature.swift in Sources */,
 				C30DBF9D252D2B4500021863 /* TimeInterval+Extension.swift in Sources */,

--- a/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
@@ -16,7 +16,7 @@ struct TaskStatusCell: View {
 
     var body: some View {
         Button(action: {
-            router.route(to: .taskDetails(taskStatus))
+            router.route(to: .taskDetails(taskStatus.task_id))
         }, label: {
             HStack {
                 switch taskStatus.status {

--- a/Stampede/Stampede/Common/Models/TaskArtifact.swift
+++ b/Stampede/Stampede/Common/Models/TaskArtifact.swift
@@ -1,0 +1,22 @@
+//
+//  TaskArtifact.swift
+//  Stampede
+//
+//  Created by David House on 10/17/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+
+public struct TaskArtifact: Codable, Equatable, Hashable {
+    let title: String
+    let type: String
+    let url: String?
+}
+
+#if DEBUG
+extension TaskArtifact {
+    static let someArtifact = TaskArtifact(title: "some artifact", type: "aType", url: nil)
+    static let someArtifacts = [someArtifact]
+}
+#endif

--- a/Stampede/Stampede/Common/Models/TaskDetails.swift
+++ b/Stampede/Stampede/Common/Models/TaskDetails.swift
@@ -1,0 +1,31 @@
+//
+//  TaskDetails.swift
+//  Stampede
+//
+//  Created by David House on 10/17/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import HouseKit
+import Combine
+
+public struct TaskDetails: Codable, Equatable, Hashable {
+    let task: TaskStatus
+    let summary: String
+    let text: String
+    let artifacts: [TaskArtifact]
+    let scmDetails: [TaskSCMDetails]
+}
+
+typealias TaskDetailsResponsePublisher = AnyPublisher<TaskDetails, ServiceError>
+
+#if DEBUG
+extension TaskDetails {
+    static let someTaskDetails = TaskDetails(task: TaskStatus.completedTask,
+                                             summary: "some summary text",
+                                             text: "some text",
+                                             artifacts: TaskArtifact.someArtifacts,
+                                             scmDetails: TaskSCMDetails.someDetails)
+}
+#endif

--- a/Stampede/Stampede/Common/Models/TaskSCMDetails.swift
+++ b/Stampede/Stampede/Common/Models/TaskSCMDetails.swift
@@ -1,0 +1,21 @@
+//
+//  TaskSCMDetails.swift
+//  Stampede
+//
+//  Created by David House on 10/17/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+
+public struct TaskSCMDetails: Codable, Equatable, Hashable {
+    let title: String
+    let value: String
+}
+
+#if DEBUG
+extension TaskSCMDetails {
+    static let someDetail = TaskSCMDetails(title: "some title", value: "some value")
+    static let someDetails = [someDetail]
+}
+#endif

--- a/Stampede/Stampede/Common/Route.swift
+++ b/Stampede/Stampede/Common/Route.swift
@@ -20,7 +20,7 @@ enum Route {
     case repositoryDetails(_ repository: Repository)
     case buildDetails(_ buildStatus: BuildStatus)
     case buildDetailsFromID(_ buildID: String)
-    case taskDetails(_ task: TaskStatus)
+    case taskDetails(_ taskID: String)
     
     // Monitor
     case monitorLive
@@ -46,8 +46,8 @@ enum Route {
             return BuildFeature.makeFeature(dependencies, build: buildStatus)
         case .buildDetailsFromID(let buildID):
             return BuildFeature.makeFeature(dependencies, buildID: buildID)
-        case .taskDetails(let task):
-            return BuildTaskFeature.makeFeature(dependencies, task: task)
+        case .taskDetails(let taskID):
+            return BuildTaskFeature.makeFeature(dependencies, taskID: taskID)
         case .monitorLive:
             return MonitorLiveFeature.makeFeature(dependencies)
         case .monitorActiveBuilds:

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeAPIEndpoint.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeAPIEndpoint.swift
@@ -15,6 +15,7 @@ public enum StampedeAPIEndpoint {
     case repositoryBuilds(String, String)
     case buildKeys(String, String, String)
     case buildDetails(String)
+    case taskDetails(String)
     // Monitor
     case monitorActiveBuilds
     case monitorActiveTasks
@@ -41,6 +42,8 @@ public enum StampedeAPIEndpoint {
             return URL(string: "\(host)/api/repository/buildKeys?owner=\(owner)&repository=\(repository)&source=\(source)")!
         case let .buildDetails(buildID):
             return URL(string: "\(host)/api/repository/buildDetails?buildID=\(buildID)")!
+        case let .taskDetails(taskID):
+            return URL(string: "\(host)/api/repository/taskDetails?taskID=\(taskID)")!
         case .monitorActiveBuilds:
             return URL(string: "\(host)/api/monitor/activeBuilds")!
         case .monitorActiveTasks:

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeService.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeService.swift
@@ -42,6 +42,10 @@ public class StampedeService: ObservableObject {
         return provider.fetchBuildDetailsPublisher(buildID: buildID)
     }
 
+    public func fetchTaskDetailsPublisher(taskID: String) -> AnyPublisher<TaskDetails, ServiceError>? {
+        return provider.fetchTaskDetailsPublisher(taskID: taskID)
+    }
+
     public func fetchAdminTasksPublisher() -> AnyPublisher<[Task], ServiceError>? {
         return provider.fetchAdminTasksPublisher()
     }

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
@@ -28,6 +28,7 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     var configQueues = Queue.someQueues
     var buildKeys = BuildKey.someBranchKeys
     var buildDetails = BuildStatus.buildCompletedHoursAgo
+    var taskDetails = TaskDetails.someTaskDetails
 
     var fetchRepositoriesPublisherCalled = false
     var fetchActiveBuildsPublisherCalled = false
@@ -43,6 +44,7 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
     var fetchAdminQueuesPublisherCalled = false
     var fetchBuildKeysPublisherCalled = false
     var fetchBuildDetailsPublisherCalled = false
+    var fetchTaskDetailsPublisherCalled = false
 
     var hostPassthroughSubject: PassthroughSubject<String, Never> = PassthroughSubject<String, Never>()
 
@@ -82,7 +84,12 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
         fetchBuildDetailsPublisherCalled = true
         return fetchPublisher(buildDetails)
     }
-    
+
+    func fetchTaskDetailsPublisher(taskID: String) -> AnyPublisher<TaskDetails, ServiceError>? {
+        fetchTaskDetailsPublisherCalled = true
+        return fetchPublisher(taskDetails)
+    }
+
     func fetchActiveBuildsPublisher() -> AnyPublisher<[BuildStatus], ServiceError>? {
         fetchActiveBuildsPublisherCalled = true
         return fetchPublisher(activeBuilds)

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceNetworkProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceNetworkProvider.swift
@@ -53,6 +53,13 @@ public class StampedeServiceNetworkProvider: NetworkProvider, StampedeServicePro
         return request(url: StampedeAPIEndpoint.buildDetails(buildID).url(host: host))
     }
 
+    public func fetchTaskDetailsPublisher(taskID: String) -> AnyPublisher<TaskDetails, ServiceError>? {
+        guard let host = host else {
+            return AnyPublisher<TaskDetails, ServiceError>(Future<TaskDetails, ServiceError> { promise in promise(.failure(.network(description: "Host not provided")))})
+        }
+        return request(url: StampedeAPIEndpoint.taskDetails(taskID).url(host: host))
+    }
+
     public func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>? {
         guard let host = host else {
             return AnyPublisher<[QueueSummary], ServiceError>(Future<[QueueSummary], ServiceError> { promise in promise(.failure(.network(description: "Host not provided")))})

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceProvider.swift
@@ -21,6 +21,7 @@ public protocol StampedeServiceProvider {
     func fetchRepositoryBuildsPublisher(owner: String, repository: String) -> AnyPublisher<[RepositoryBuild], ServiceError>?
     func fetchBuildKeysPublisher(owner: String, repository: String, source: String) -> AnyPublisher<[BuildKey], ServiceError>?
     func fetchBuildDetailsPublisher(buildID: String) -> AnyPublisher<BuildStatus, ServiceError>?
+    func fetchTaskDetailsPublisher(taskID: String) -> AnyPublisher<TaskDetails, ServiceError>?
 
     // Monitor
     func fetchActiveBuildsPublisher() -> AnyPublisher<[BuildStatus], ServiceError>?

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
@@ -12,13 +12,14 @@ class BuildTaskFeature: BaseFeature {
     
     // MARK: - Static methods
     
-    static func makeFeature(_ dependencies: Dependencies, task: TaskStatus) -> BaseFeature {
-        return BuildTaskFeature(dependencies: dependencies, task: task)
+    static func makeFeature(_ dependencies: Dependencies, taskID: String) -> BaseFeature {
+        return BuildTaskFeature(dependencies: dependencies, taskID: taskID)
     }
     
     // MARK: - Private Properties
     
     private var viewModel: BuildTaskViewModel
+    private var taskID: String
 
     // MARK: - Overrides
     
@@ -32,8 +33,9 @@ class BuildTaskFeature: BaseFeature {
 
     // MARK: - Initializer
     
-    init(dependencies: Dependencies, task: TaskStatus) {
-        viewModel = BuildTaskViewModel(task: task)
+    init(dependencies: Dependencies, taskID: String) {
+        viewModel = BuildTaskViewModel(state: .loading)
+        self.taskID = taskID
         super.init(dependencies: dependencies)
     }
     
@@ -45,7 +47,10 @@ class BuildTaskFeature: BaseFeature {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = viewModel.task.task
         navigationItem.largeTitleDisplayMode = .automatic
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        viewModel.publisher = dependencies.service.fetchTaskDetailsPublisher(taskID: taskID)
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
@@ -13,48 +13,62 @@ struct BuildTaskView: View {
     @EnvironmentObject var viewModel: BuildTaskViewModel
 
     var body: some View {
-        List {
-            Section(header: Text("Task Information")) {
-                HStack {
-                    PrimaryLabel("Task")
-                    Spacer()
-                    PrimaryLabel(viewModel.task.task)
-                }
+        BaseView(viewModel: viewModel, content: { taskDetails in
+            List {
+                Section(header: Text("Task Information")) {
+                    HStack {
+                        PrimaryLabel("Task")
+                        Spacer()
+                        PrimaryLabel(taskDetails.task.task)
+                    }
 
-                HStack {
-                    PrimaryLabel("Conclusion")
-                    Spacer()
-                    ValueLabel(viewModel.task.conclusion ?? "")
-                }
+                    HStack {
+                        PrimaryLabel("Conclusion")
+                        Spacer()
+                        ValueLabel(taskDetails.task.conclusion ?? "")
+                    }
 
-                HStack {
-                    PrimaryLabel("Node")
-                    Spacer()
-                    ValueLabel(viewModel.task.node ?? "")
-                }
+                    HStack {
+                        PrimaryLabel("Node")
+                        Spacer()
+                        ValueLabel(taskDetails.task.node ?? "")
+                    }
 
-                HStack {
-                    PrimaryLabel("Duration")
-                    Spacer()
-                    ValueLabel(viewModel.task.duration)
+                    HStack {
+                        PrimaryLabel("Duration")
+                        Spacer()
+                        ValueLabel(taskDetails.task.duration)
+                    }
+
+                    ForEach(taskDetails.scmDetails, id: \.self) { detail in
+                        HStack {
+                            PrimaryLabel(detail.title)
+                            Spacer()
+                            ValueLabel(detail.value)
+                        }
+                    }
+                }
+                if taskDetails.artifacts.count > 0 {
+                    Section(header: Text("Artifacts")) {
+                        ForEach(taskDetails.artifacts, id: \.self) { artifact in
+                            HStack {
+                                PrimaryLabel(artifact.title)
+                                Spacer()
+                                ValueLabel(artifact.type)
+                            }
+                        }
+                    }
+                }
+                Section(header: Text("Summary")) {
+                    Text(taskDetails.summary)
+                }
+                if taskDetails.text != "" {
+                    Section(header: Text("Text")) {
+                        Text(taskDetails.text)
+                    }
                 }
             }
-            Section(header: Text("Task Config")) {
-                Text("Hello")
-            }
-            Section(header: Text("Task Results")) {
-                Text("Hello")
-            }
-            Section(header: Text("Artifacts")) {
-                Text("Hello")
-            }
-            Section(header: Text("Summary")) {
-                Text("Hello")
-            }
-            Section(header: Text("Text")) {
-                Text("Hello")
-            }
-        }
+        })
     }
 }
 
@@ -62,7 +76,7 @@ struct BuildTaskView: View {
 struct BuildTaskView_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
-            BuildTaskView().environmentObject(BuildTaskViewModel(task: TaskStatus.completedTask))
+            BuildTaskView().environmentObject(BuildTaskViewModel(state: .results(TaskDetails.someTaskDetails)))
         }
     }
 }

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskViewModel.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskViewModel.swift
@@ -7,12 +7,6 @@
 //
 
 import Foundation
+import HouseKit
 
-class BuildTaskViewModel: ObservableObject {
-
-    @Published var task: TaskStatus
-
-    init(task: TaskStatus) {
-        self.task = task
-    }
-}
+class BuildTaskViewModel: BaseViewModel<TaskDetails> { }

--- a/Stampede/Stampede/Features/Build/BuildView.swift
+++ b/Stampede/Stampede/Features/Build/BuildView.swift
@@ -63,7 +63,7 @@ struct BuildView: View {
                 Section(header: Text("Tasks")) {
                     ForEach(buildStatus.tasks) { task in
                         Button(action: {
-                            router.route(to: .taskDetails(task))
+                            router.route(to: .taskDetails(task.task_id))
                         }, label: {
                             TaskStatusCell(taskStatus: task)
                         })

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -22,7 +22,7 @@ struct HistoryTasksView: View {
             List {
                 ForEach(tasks, id: \.self) { item in
                     Button(action: {
-                        router.route(to: .taskDetails(item))
+                        router.route(to: .taskDetails(item.task_id))
                     }, label: {
                         TaskStatusCell(taskStatus: item)
                     })

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
@@ -23,7 +23,7 @@ struct MonitorActiveTasksView: View {
                 if tasks.count > 0 {
                     ForEach(tasks, id: \.self) { item in
                         Button(action: {
-                            router.route(to: .taskDetails(item))
+                            router.route(to: .taskDetails(item.task_id))
                         }, label: {
                             TaskStatusCell(taskStatus: item)
                         })


### PR DESCRIPTION
This PR refactors the task details screen so it can show additional details about the task. This involved using the new server API for getting a single task details.

closes #28 
