### PR TITLE
♻️ Simplified the live monitor view

### DIFF
--- a/Stampede/Stampede/Common/ComponentViews/View/QueueChartView.swift
+++ b/Stampede/Stampede/Common/ComponentViews/View/QueueChartView.swift
@@ -10,23 +10,23 @@ import SwiftUI
 
 struct QueueChartView: View {
 
-    let measurements: [QueueGaugeInfo]
+    let measurements: [Int]
     let maxCount: Int
 
-    init(measurements: [QueueGaugeInfo]) {
+    init(measurements: [Int]) {
         self.measurements = measurements
-        maxCount = measurements.map { $0.active + $0.queued }.max() ?? 0
+        maxCount = measurements.max() ?? 0
     }
 
     var body: some View {
-        if maxCount > 0 {
+        if measurements.count > 0 {
             GeometryReader { reader in
                 HStack(alignment: .bottom, spacing: 2.0) {
-                    ForEach(0..<self.measurements.count) { i in
+                    ForEach(self.measurements, id: \.self) { i in
                         VStack(spacing: 0.0) {
                             Spacer()
                             Rectangle()
-                                .barHeight(reader.size.height, max: maxCount, info: self.measurements[i])
+                                .barHeight(reader.size.height, max: maxCount, measurement: i)
                         }
                     }
                 }
@@ -38,22 +38,16 @@ struct QueueChartView: View {
 }
 
 extension Rectangle {
-    func barHeight(_ height: CGFloat, max: Int, info: QueueGaugeInfo) -> some View {
-        guard max > 0, info.total > 0 else {
+    func barHeight(_ height: CGFloat, max: Int, measurement: Int) -> some View {
+        guard max > 0, measurement > 0 else {
             return self
                 .fill(Color.blue)
                 .frame(height: 1.0)
         }
 
-        if info.queued > 0 {
-            return self
-                .fill(Color.purple)
-                .frame(height: height * CGFloat(CGFloat(info.total) / CGFloat(max)))
-        } else {
-            return self
-                .fill(Color.green)
-                .frame(height: height * CGFloat(CGFloat(info.total) / CGFloat(max)))
-        }
+        return self
+            .fill(Color.purple)
+            .frame(height: height * CGFloat(CGFloat(measurement) / CGFloat(max)))
     }
 }
 
@@ -61,16 +55,9 @@ struct QueueChartView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             QueueChartView(measurements: [])
-            QueueChartView(measurements: [QueueGaugeInfo(title: "", idle: 0, active: 0, queued: 0)])
-            QueueChartView(measurements: [
-                QueueGaugeInfo(title: "", idle: 4, active: 0, queued: 0),
-                QueueGaugeInfo(title: "", idle: 3, active: 1, queued: 0),
-                QueueGaugeInfo(title: "", idle: 2, active: 2, queued: 0),
-                QueueGaugeInfo(title: "", idle: 0, active: 4, queued: 0),
-                QueueGaugeInfo(title: "", idle: 0, active: 4, queued: 4),
-                QueueGaugeInfo(title: "", idle: 0, active: 4, queued: 2),
-                QueueGaugeInfo(title: "", idle: 4, active: 0, queued: 0)
-            ])
+            QueueChartView(measurements: [0])
+            QueueChartView(measurements: [0, 0, 4, 1, 5, 6, 0, 0, 0, 2, 3])
+            QueueChartView(measurements: [4, 4, 5, 2, 7, 12, 3, 5, 6, 7, 8, 9])
         }
     }
 }

--- a/Stampede/Stampede/Common/ComponentViews/View/QueueGaugeView.swift
+++ b/Stampede/Stampede/Common/ComponentViews/View/QueueGaugeView.swift
@@ -12,35 +12,6 @@ struct QueueGaugeInfo: Hashable {
     let title: String
     let idle: Int
     let active: Int
-    let queued: Int
-
-    var idlePct: CGFloat {
-        if total == 0 {
-            return 0.0
-        } else {
-            return CGFloat(idle) / CGFloat(total)
-        }
-    }
-
-    var activePct: CGFloat {
-        if total == 0 {
-            return 0.0
-        } else {
-            return CGFloat(active) / CGFloat(total)
-        }
-    }
-
-    var queuedPct: CGFloat {
-        if total == 0 {
-            return 0.0
-        } else {
-            return CGFloat(queued) / CGFloat(total)
-        }
-    }
-
-    var total: Int {
-        return active + queued
-    }
 }
 
 struct QueueGaugeView: View {
@@ -51,7 +22,6 @@ struct QueueGaugeView: View {
         let color: Color
     }
 
-    private let outerPieces: [QueueGaugePieceInfo]
     private let innerPieces: [QueueGaugePieceInfo]
     private let title: String
 
@@ -59,8 +29,8 @@ struct QueueGaugeView: View {
         var generatedPieces: [QueueGaugePieceInfo] = []
         let total: Int = info.active + info.idle
         let pieceGap: Double = 1.0
-        var totalSize: Double = 360.0 - Double(pieceGap * Double(total))
-        var pieceSize: Double = totalSize / Double(total)
+        let totalSize: Double = 360.0 - Double(pieceGap * Double(total))
+        let pieceSize: Double = totalSize / Double(total)
         var start = 0.0
 
         for _ in 0..<info.idle {
@@ -82,17 +52,6 @@ struct QueueGaugeView: View {
             )
         }
         innerPieces = generatedPieces
-
-        var queuedPieces: [QueueGaugePieceInfo] = []
-        totalSize = 360.0 - Double(pieceGap * Double(info.queued))
-        pieceSize = totalSize / Double(info.queued)
-        start = 0.0
-        for _ in 0..<info.queued {
-            queuedPieces.append(QueueGaugePieceInfo(start: start, end: start + pieceSize, color: Color.purple))
-            start += pieceSize
-            start += pieceGap
-        }
-        outerPieces = queuedPieces
         title = info.title
     }
     
@@ -100,14 +59,7 @@ struct QueueGaugeView: View {
         GeometryReader { reader in
             ZStack {
                 ZStack {
-                    ForEach(0..<self.outerPieces.count) { i in
-                        QueueGaugePiece(startDegrees: self.outerPieces[i].start, endDegrees: self.outerPieces[i].end)
-                            .stroke(lineWidth: reader.size.height * 0.03)
-                            .fill(self.outerPieces[i].color)
-                    }
-                }.scaleEffect(1.25)
-                ZStack {
-                    ForEach(0..<self.innerPieces.count) { i in
+                    ForEach(0..<self.innerPieces.count, id: \.self) { i in
                         QueueGaugePiece(startDegrees: self.innerPieces[i].start, endDegrees: self.innerPieces[i].end)
                             .stroke(lineWidth: reader.size.height * 0.05)
                             .fill(self.innerPieces[i].color)
@@ -137,10 +89,11 @@ struct QueueGaugePiece: Shape {
 struct QueueGaugeView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            QueueGaugeView(info: QueueGaugeInfo(title: "empty", idle: 0, active: 0, queued: 0)).previewDependencies()
-            QueueGaugeView(info: QueueGaugeInfo(title: "first", idle: 4, active: 0, queued: 0)).previewDependencies()
-            QueueGaugeView(info: QueueGaugeInfo(title: "second", idle: 2, active: 8, queued: 0)).previewDependencies()
-            QueueGaugeView(info: QueueGaugeInfo(title: "third", idle: 0, active: 8, queued: 3)).previewDependencies()
+            QueueGaugeView(info: QueueGaugeInfo(title: "empty", idle: 0, active: 0)).previewDependencies()
+            QueueGaugeView(info: QueueGaugeInfo(title: "some", idle: 2, active: 0)).previewDependencies()
+            QueueGaugeView(info: QueueGaugeInfo(title: "first", idle: 4, active: 0)).previewDependencies()
+            QueueGaugeView(info: QueueGaugeInfo(title: "second", idle: 2, active: 8)).previewDependencies()
+            QueueGaugeView(info: QueueGaugeInfo(title: "third", idle: 0, active: 8)).previewDependencies()
         }
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveFeature.swift
@@ -19,7 +19,7 @@ class MonitorLiveFeature: BaseFeature {
     
     // MARK: - Private Properties
     
-    private var viewModel = MonitorLiveViewModel(state: .loading)
+    private var viewModel = MonitorLiveViewModel()
 
     // MARK: - Overrides
     
@@ -39,6 +39,14 @@ class MonitorLiveFeature: BaseFeature {
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        
+        viewModel.workersPublisher = dependencies.service.fetchWorkerStatusPublisher()
+        viewModel.queuesPublisher = dependencies.service.fetchMonitorQueuesPublisher()
+        viewModel.startMonitoring()
+        UIApplication.shared.isIdleTimerDisabled = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        viewModel.stopMonitoring()
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorLive/MonitorLiveView.swift
@@ -12,33 +12,16 @@ struct MonitorLiveView: View {
 
     // MARK: - Environment
 
-    // MARK: - Observed Objects
-
     @EnvironmentObject var viewModel: MonitorLiveViewModel
-    
-    private var columns: [GridItem] = [
-        GridItem(.adaptive(minimum: 300))
-    ]
 
     // MARK: - View
     var body: some View {
-        switch viewModel.state {
-        case .loading:
-            Text("Loading...")
-        case .networkError(let error):
-            NetworkErrorView(error: error)
-        case .results(let results):
-//            ScrollView {
-//                LazyVGrid(columns: columns) {
-//                    ForEach(viewModel.queueGauges, id: \.self) { gauge in
-//                        VStack {
-//                            QueueChartView(measurements: gauge.history).aspectRatio(contentMode: .fit)
-//                            PrimaryLabel(gauge.title)
-//                        }
-//                    }
-//                }
-//            }
-            Text("Results?")
+        VStack {
+            QueueGaugeView(info: viewModel.gaugeInfo)
+            Spacer()
+            QueueChartView(measurements: viewModel.queueDepths)
+            Text("Queue Depth")
+            Spacer()
         }
     }
 }
@@ -46,13 +29,8 @@ struct MonitorLiveView: View {
 #if DEBUG
 struct MonitorLiveView_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
-//            MonitorLiveView(viewModel: MonitorLiveViewModel.oneIdleQueue).previewDependencies()
-//            MonitorLiveView(viewModel: MonitorLiveViewModel.onePartialQueue).previewDependencies()
-//            MonitorLiveView(viewModel: MonitorLiveViewModel.oneFullQueue).previewDependencies()
-//            MonitorLiveView(viewModel: MonitorLiveViewModel.oneQueuedQueue).previewDependencies()
-//            MonitorLiveView(viewModel: MonitorLiveViewModel.twoQueues).previewDependencies()
-//            MonitorLiveView(viewModel: MonitorLiveViewModel.allQueues).previewDependencies()
+        Previewer {
+            MonitorLiveView().environmentObject(MonitorLiveViewModel.someViewModel)
         }
     }
 }


### PR DESCRIPTION
This PR updates the live monitor view to include just a single gauge of workers and a chart of the queue depths.

closes #8 
