### PR TITLE
✨ Added message when no rows in history

### DIFF
--- a/Stampede/Stampede-Tests/Common/Models/BuildStatusTests.swift
+++ b/Stampede/Stampede-Tests/Common/Models/BuildStatusTests.swift
@@ -12,6 +12,7 @@ import XCTest
 class BuildStatusTests: XCTestCase {
     
     func testStatusIndicatorGeneratedCorrectly() {
+        XCTFail("testing!")
         XCTAssertEqual(BuildStatus.someActiveBuild.statusIndicator, .inProgress)
         XCTAssertEqual(BuildStatus.someRecentSuccessBuild.statusIndicator, .success)
         XCTAssertEqual(BuildStatus.someRecentFailedBuild.statusIndicator, .failure)

--- a/Stampede/Stampede-Tests/Common/Models/BuildStatusTests.swift
+++ b/Stampede/Stampede-Tests/Common/Models/BuildStatusTests.swift
@@ -12,7 +12,6 @@ import XCTest
 class BuildStatusTests: XCTestCase {
     
     func testStatusIndicatorGeneratedCorrectly() {
-        XCTFail("testing!")
         XCTAssertEqual(BuildStatus.someActiveBuild.statusIndicator, .inProgress)
         XCTAssertEqual(BuildStatus.someRecentSuccessBuild.statusIndicator, .success)
         XCTAssertEqual(BuildStatus.someRecentFailedBuild.statusIndicator, .failure)

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
@@ -20,8 +20,12 @@ struct HistoryBuildsView: View {
     var body: some View {
         BaseView(viewModel: viewModel, content: { activeBuilds in
             List {
-                ForEach(activeBuilds, id: \.self) { item in
-                    BuildDetailsCell(buildDetails: item)
+                if activeBuilds.count > 0 {
+                    ForEach(activeBuilds, id: \.self) { item in
+                        BuildDetailsCell(buildDetails: item)
+                    }
+                } else {
+                    Text("No builds found")
                 }
             }
             .listStyle(DefaultListStyle())
@@ -36,6 +40,7 @@ struct HistoryBuildsView_Previews: PreviewProvider {
             HistoryBuildsView().environmentObject(HistoryBuildsViewModel.loading)
             HistoryBuildsView().environmentObject(HistoryBuildsViewModel.networkError)
             HistoryBuildsView().environmentObject(HistoryBuildsViewModel.someBuilds)
+            HistoryBuildsView().environmentObject(HistoryBuildsViewModel.noBuilds)
         }
     }
 }

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
@@ -12,7 +12,7 @@ import HouseKit
 
 class HistoryBuildsViewModel: BaseViewModel<[BuildDetails]> {
 
-    let X: XXX
+    let X: XXY
 }
 
 #if DEBUG

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
@@ -10,10 +10,7 @@ import Foundation
 import SwiftUI
 import HouseKit
 
-class HistoryBuildsViewModel: BaseViewModel<[BuildDetails]> {
-
-    let X: XXZ
-}
+class HistoryBuildsViewModel: BaseViewModel<[BuildDetails]> { }
 
 #if DEBUG
 extension HistoryBuildsViewModel {

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
@@ -10,12 +10,16 @@ import Foundation
 import SwiftUI
 import HouseKit
 
-class HistoryBuildsViewModel: BaseViewModel<[BuildDetails]> { }
+class HistoryBuildsViewModel: BaseViewModel<[BuildDetails]> {
+
+    let X: XXX
+}
 
 #if DEBUG
 extension HistoryBuildsViewModel {
     static let loading = HistoryBuildsViewModel(state: .loading)
     static let networkError = HistoryBuildsViewModel(state: .networkError(.network(description: "some error")))
     static let someBuilds = HistoryBuildsViewModel(state: .results([BuildDetails.completedBuild]))
+    static let noBuilds = HistoryBuildsViewModel(state: .results([]))
 }
 #endif

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsViewModel.swift
@@ -12,7 +12,7 @@ import HouseKit
 
 class HistoryBuildsViewModel: BaseViewModel<[BuildDetails]> {
 
-    let X: XXY
+    let X: XXZ
 }
 
 #if DEBUG

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -20,12 +20,16 @@ struct HistoryTasksView: View {
     var body: some View {
         BaseView(viewModel: viewModel, content: { tasks in
             List {
-                ForEach(tasks, id: \.self) { item in
-                    Button(action: {
-                        router.route(to: .taskDetails(item.task_id))
-                    }, label: {
-                        TaskStatusCell(taskStatus: item)
-                    })
+                if tasks.count > 0 {
+                    ForEach(tasks, id: \.self) { item in
+                        Button(action: {
+                            router.route(to: .taskDetails(item.task_id))
+                        }, label: {
+                            TaskStatusCell(taskStatus: item)
+                        })
+                    }
+                } else {
+                    Text("No tasks found")
                 }
             }
             .listStyle(DefaultListStyle())


### PR DESCRIPTION
This PR adds a message when no details are found in the History Tasks and History Builds screens.

closes #63 
