### PR TITLE
♻️ Now just showing build number in the build list

### DIFF
--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildDetailsCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildDetailsCell.swift
@@ -20,7 +20,7 @@ struct BuildDetailsCell: View {
         }, label: {
             HStack {
                 VStack(alignment: .leading) {
-                    PrimaryLabel(buildDetails.build_id)
+                    PrimaryLabel("\(buildDetails.build)")
                 }
                 Spacer()
                 ValueLabel(buildDetails.completedAgo)


### PR DESCRIPTION
This PR changes the build list to show the build number instead of the full build id. That keeps the UI a bit more clean.

closes #55 
