### PR TITLE
♻️ Added more context to active and history build views

### DIFF
--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildDetailsCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildDetailsCell.swift
@@ -20,7 +20,8 @@ struct BuildDetailsCell: View {
         }, label: {
             HStack {
                 VStack(alignment: .leading) {
-                    PrimaryLabel("\(buildDetails.build)")
+                    PrimaryLabel(buildDetails.repository)
+                    SecondaryLabel("\(buildDetails.build_key)-\(buildDetails.build)")
                 }
                 Spacer()
                 ValueLabel(buildDetails.completedAgo)

--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildStatusCell.swift
@@ -19,16 +19,9 @@ struct BuildStatusCell: View {
             router.route(to: BuildRoute(build: buildStatus, buildID: nil))
         }, label: {
             HStack {
-                switch buildStatus.statusIndicator {
-                case .inProgress:
-                    CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
-                case .failure:
-                    CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
-                case .success:
-                    CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
-                }
                 VStack(alignment: .leading) {
-                    PrimaryLabel(buildStatus.buildIdentifier)
+                    PrimaryLabel(buildStatus.buildDetails.repository)
+                    SecondaryLabel(buildStatus.buildIdentifier)
                 }
                 Spacer()
                 ValueLabel(buildStatus.startedAgo)
@@ -42,6 +35,7 @@ struct BuildStatusCell: View {
 struct BuildStatusCell_Previews: PreviewProvider {
     static var previews: some View {
         Previewer {
+            BuildStatusCell(buildStatus: BuildStatus.someActiveBuild)
             BuildStatusCell(buildStatus: BuildStatus.someRecentBuild)
         }
     }

--- a/Stampede/Stampede/Common/Models/BuildDetails.swift
+++ b/Stampede/Stampede/Common/Models/BuildDetails.swift
@@ -44,7 +44,7 @@ typealias BuildDetailsResponsePublisher = AnyPublisher<[BuildDetails], ServiceEr
 
 extension BuildDetails {
     public static let activeBuild = BuildDetails(build_id: "12345", owner: "davidahouse", repository: "some-repository", build_key: "pullrequest-42", build: 12, status: "in_progress", started_at: Date().addingTimeInterval(-60*5), completed_at: nil)
-    public static let completedBuild = BuildDetails(build_id: "12345", owner: "davidahouse", repository: "some-repository", build_key: "pullrequest-42", build: 12, status: "success", started_at: Date().addingTimeInterval(-60*5), completed_at: Date())
+    public static let completedBuild = BuildDetails(build_id: "12345", owner: "davidahouse", repository: "some-repository", build_key: "pullrequest-42", build: 13, status: "success", started_at: Date().addingTimeInterval(-60*5), completed_at: Date())
     
     public static let buildStartedSecondsAgo = BuildDetails(build_id: "12345", owner: "davidahouse", repository: "some-repository", build_key: "pullrequest-42", build: 12, status: "in_progress", started_at: Date().addingTimeInterval(-12), completed_at: nil)
     public static let buildStartedMinutesAgo = BuildDetails(build_id: "12345", owner: "davidahouse", repository: "some-repository", build_key: "pullrequest-42", build: 12, status: "in_progress", started_at: Date().addingTimeInterval(-12*60), completed_at: nil)

--- a/Stampede/Stampede/Common/Models/BuildStatus.swift
+++ b/Stampede/Stampede/Common/Models/BuildStatus.swift
@@ -83,7 +83,7 @@ extension BuildStatus {
     public static let someRecentSuccessBuild = BuildStatus(buildID: "123467", buildDetails: BuildDetails.completedBuild, tasks: [TaskStatus.completedTask])
     public static let someRecentFailedBuild = BuildStatus(buildID: "123467", buildDetails: BuildDetails.completedBuild, tasks: [TaskStatus.failedTask])
 
-    public static let activeBuilds = [BuildStatus.someActiveBuild, BuildStatus.someActiveSuccessBuild, BuildStatus.someActiveFailedBuild]
+    public static let activeBuilds = [BuildStatus.someActiveBuild]
     public static let recentBuilds = [BuildStatus.someRecentBuild, BuildStatus.someRecentSuccessBuild, BuildStatus.someRecentFailedBuild]
     
     public static let buildStartedSecondsAgo = BuildStatus(buildID: "12345", buildDetails: BuildDetails.buildStartedSecondsAgo, tasks: [TaskStatus.inProgressTask, TaskStatus.queuedTask])

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsViewModel.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsViewModel.swift
@@ -15,6 +15,6 @@ class MonitorActiveBuildsViewModel: BaseViewModel<[BuildStatus]> { }
 extension MonitorActiveBuildsViewModel {
     static let loading = MonitorActiveBuildsViewModel(state: .loading)
     static let networkError = MonitorActiveBuildsViewModel(state: .networkError(.network(description: "some error")))
-    static let someBuilds = MonitorActiveBuildsViewModel(state: .results(BuildStatus.recentBuilds))
+    static let someBuilds = MonitorActiveBuildsViewModel(state: .results(BuildStatus.activeBuilds))
 }
 #endif


### PR DESCRIPTION
This PR changes the cell display for Active and History build list. Now there is more context for the build displayed instead of just the build number.

closes #79 
