### PR TITLE
♻️Refactor routes further

### DIFF
--- a/Stampede/Stampede-Tests/Common/RoutesTests.swift
+++ b/Stampede/Stampede-Tests/Common/RoutesTests.swift
@@ -1,0 +1,75 @@
+//
+//  RoutesTests.swift
+//  Stampede-Tests
+//
+//  Created by David House on 11/7/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import XCTest
+@testable import Stampede
+
+class RoutesTests: XCTestCase {
+
+    let routes = Routes()
+    var dependencies: Dependencies!
+    var fixtureProvider = StampedeServiceFixtureProvider()
+
+    override func setUp() {
+        super.setUp()
+        dependencies = Dependencies(serviceProvider: fixtureProvider)
+    }
+
+    func testCanRouteUsingRepository() {
+        let route = routes.route(for: Repository.someRepository)
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteToMainMenuItems() {
+        for item in MainMenuItem.allCases {
+            let route = routes.route(for: item)
+            XCTAssertNotNil(route.makeFeature(dependencies).view)
+        }
+    }
+
+    func testCanRouteToBuildStatus() {
+        let route = routes.route(for: BuildStatus.someActiveBuild)
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteToBuildID() {
+        let route = routes.routeForBuildID("123")
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteToTaskID() {
+        let route = routes.routeForTask("123")
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteToRepositoryBuild() {
+        let route = routes.routeForRepositoryBuild(Repository.someRepository, build: "some-build")
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteToRepositoryBuildKey() {
+        let route = routes.routeForRepositorySourceDetails(Repository.someRepository, buildKey: "some-build")
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteSettingsDeveloperPersonaRoute() {
+        let route = routes.routeSettingsDeveloperPersonaRoute()
+        XCTAssertNotNil(route.makeFeature(dependencies).view)
+    }
+
+    func testCanRouteToArtifactTypes() {
+        let types: [TaskArtifact] = [TaskArtifact.clocArtifact,
+                                   TaskArtifact.xcodeBuildArtifact,
+                                   TaskArtifact.linkArtifact,
+                                   TaskArtifact.someArtifact]
+        for type in types {
+            let route = routes.routeForArtifact("some-task", artifact: type)
+            XCTAssertNotNil(route.makeFeature(dependencies).view)
+        }
+    }
+}

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		C3520CAF23CEA321004C0674 /* RepositoryFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3520CAE23CEA321004C0674 /* RepositoryFeatureTests.swift */; };
 		C3520CB123CEA33C004C0674 /* RepositoryViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3520CB023CEA33C004C0674 /* RepositoryViewTests.swift */; };
 		C35D51B02353C5DF00FDA4A8 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35D51AF2353C5DF00FDA4A8 /* MainView.swift */; };
+		C3669350255441E60008C1EC /* Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C366934F255441E60008C1EC /* Routes.swift */; };
 		C3804FD0248EEB55008A302B /* QueueChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3804FCF248EEB55008A302B /* QueueChartView.swift */; };
 		C3816C79248702AB00E6980B /* MonitorActiveBuildsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3816C6F248702AB00E6980B /* MonitorActiveBuildsFeature.swift */; };
 		C3816C7A248702AB00E6980B /* MonitorActiveBuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3816C70248702AB00E6980B /* MonitorActiveBuildsView.swift */; };
@@ -364,6 +365,7 @@
 		C3520CB023CEA33C004C0674 /* RepositoryViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewTests.swift; sourceTree = "<group>"; };
 		C35D51AC2353A40200FDA4A8 /* RepositoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryView.swift; sourceTree = "<group>"; };
 		C35D51AF2353C5DF00FDA4A8 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		C366934F255441E60008C1EC /* Routes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routes.swift; sourceTree = "<group>"; };
 		C3804FCF248EEB55008A302B /* QueueChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueChartView.swift; sourceTree = "<group>"; };
 		C3816C6F248702AB00E6980B /* MonitorActiveBuildsFeature.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonitorActiveBuildsFeature.swift; sourceTree = "<group>"; };
 		C3816C70248702AB00E6980B /* MonitorActiveBuildsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MonitorActiveBuildsView.swift; sourceTree = "<group>"; };
@@ -804,6 +806,7 @@
 				C30DBFDD2532236C00021863 /* BaseFeature.swift */,
 				C30DBFF22532308900021863 /* Dependencies.swift */,
 				9455103E253383A7007A1299 /* Route.swift */,
+				C366934F255441E60008C1EC /* Routes.swift */,
 				C30DC0062533B4F900021863 /* Router.swift */,
 				C3850A24253739100057F500 /* BaseView.swift */,
 				C3850A2925373C620057F500 /* BaseSubView.swift */,
@@ -1761,6 +1764,7 @@
 				C3081AC524563CBE000C20F1 /* BuildView.swift in Sources */,
 				94B571F624BBBECD00CA13A4 /* BuildStatus.swift in Sources */,
 				C3B1229A253D0479005FD154 /* ArtifactCloc.swift in Sources */,
+				C3669350255441E60008C1EC /* Routes.swift in Sources */,
 				94B571FE24BBBECD00CA13A4 /* StampedeService.swift in Sources */,
 				94E913AE24BB512B0056A150 /* BuildTaskViewModel.swift in Sources */,
 				C3126DA223BED33400AC542F /* SecondaryLabel.swift in Sources */,

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		C3B1229A253D0479005FD154 /* ArtifactCloc.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B12299253D0479005FD154 /* ArtifactCloc.swift */; };
 		C3B1229F253D05F2005FD154 /* ArtifactClocView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B1229E253D05F2005FD154 /* ArtifactClocView.swift */; };
 		C3B1D62B23AE8598002CCE66 /* XCTestCase+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B1D62A23AE8598002CCE66 /* XCTestCase+Extension.swift */; };
+		C3B74F8C25576507004C5AF8 /* RoutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B74F8B25576507004C5AF8 /* RoutesTests.swift */; };
 		C3CA2E0C24BA9EA10086B71D /* HistoryBuildsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CA2E0B24BA9EA10086B71D /* HistoryBuildsFeature.swift */; };
 		C3CA2E0E24BA9EB50086B71D /* HistoryBuildsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CA2E0D24BA9EB50086B71D /* HistoryBuildsView.swift */; };
 		C3CA2E1024BA9EC00086B71D /* HistoryBuildsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3CA2E0F24BA9EC00086B71D /* HistoryBuildsViewModel.swift */; };
@@ -423,6 +424,7 @@
 		C3B12299253D0479005FD154 /* ArtifactCloc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactCloc.swift; sourceTree = "<group>"; };
 		C3B1229E253D05F2005FD154 /* ArtifactClocView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactClocView.swift; sourceTree = "<group>"; };
 		C3B1D62A23AE8598002CCE66 /* XCTestCase+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extension.swift"; sourceTree = "<group>"; };
+		C3B74F8B25576507004C5AF8 /* RoutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesTests.swift; sourceTree = "<group>"; };
 		C3CA2E0B24BA9EA10086B71D /* HistoryBuildsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryBuildsFeature.swift; sourceTree = "<group>"; };
 		C3CA2E0D24BA9EB50086B71D /* HistoryBuildsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryBuildsView.swift; sourceTree = "<group>"; };
 		C3CA2E0F24BA9EC00086B71D /* HistoryBuildsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryBuildsViewModel.swift; sourceTree = "<group>"; };
@@ -543,6 +545,7 @@
 				C3DDDC142518092D005C8189 /* ConstantsTests.swift */,
 				C3DE1CB5254241D2009FA36D /* RouterTests.swift */,
 				C3DE1CC92543365A009FA36D /* BaseFeatureTests.swift */,
+				C3B74F8B25576507004C5AF8 /* RoutesTests.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1873,6 +1876,7 @@
 				C38BDD7F254504A300CA9A48 /* FavoriteRepositoryCellTests.swift in Sources */,
 				C3DDDC1A251809AC005C8189 /* QueueGaugeViewTests.swift in Sources */,
 				C3D350F723C2B00600ADEDC9 /* CurrentThemeTests.swift in Sources */,
+				C3B74F8C25576507004C5AF8 /* RoutesTests.swift in Sources */,
 				941F25D823C2A71000EC3E36 /* ValueLabelTests.swift in Sources */,
 				C3816C8D248702BC00E6980B /* MonitorActiveBuildsFeatureTests.swift in Sources */,
 				C3DE1C462541BF93009FA36D /* MonitorLiveFeatureTestts.swift in Sources */,

--- a/Stampede/Stampede/Common/BaseFeature.swift
+++ b/Stampede/Stampede/Common/BaseFeature.swift
@@ -18,10 +18,12 @@ class BaseFeature: UIViewController {
 
     let dependencies: Dependencies
     let router: Router
+    let routes: Routes
 
     init(dependencies: Dependencies, routerDelegate: RouterDelegate? = nil) {
         self.dependencies = dependencies
         router = Router()
+        routes = Routes()
         super.init(nibName: nil, bundle: nil)
         if let routerDelegate = routerDelegate {
             router.delegate = routerDelegate

--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildDetailsCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildDetailsCell.swift
@@ -11,12 +11,13 @@ import SwiftUI
 struct BuildDetailsCell: View {
 
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     let buildDetails: BuildDetails
 
     var body: some View {
         Button(action: {
-            router.route(to: BuildRoute(build: nil, buildID: buildDetails.build_id))
+            router.route(to: routes.routeForBuildID(buildDetails.build_id))
         }, label: {
             HStack {
                 VStack(alignment: .leading) {

--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildKeyCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildKeyCell.swift
@@ -13,10 +13,11 @@ struct BuildKeyCell: View {
     let buildKey: BuildKey
 
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     var body: some View {
         Button(action: {
-            router.route(to: RepositorySourceDetailsRoute(repository: repository, buildKey: buildKey.buildKey))
+            router.route(to: routes.routeForRepositorySourceDetails(repository, buildKey: buildKey.buildKey))
         }, label: {
             HStack {
                 VStack(alignment: .leading) {

--- a/Stampede/Stampede/Common/ComponentViews/Cells/BuildStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/BuildStatusCell.swift
@@ -11,12 +11,13 @@ import SwiftUI
 struct BuildStatusCell: View {
 
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
     
     let buildStatus: BuildStatus
 
     var body: some View {
         Button(action: {
-            router.route(to: BuildRoute(build: buildStatus, buildID: nil))
+            router.route(to: routes.route(for: buildStatus))
         }, label: {
             HStack {
                 VStack(alignment: .leading) {

--- a/Stampede/Stampede/Common/ComponentViews/Cells/RepositoryBuildCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/RepositoryBuildCell.swift
@@ -14,10 +14,11 @@ struct RepositoryBuildCell: View {
     let repositoryBuild: RepositoryBuild
 
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     var body: some View {
         Button(action: {
-            router.route(to: RepositoryBuildDetailsRoute(repository: repository, build: repositoryBuild.build))
+            router.route(to: routes.routeForRepositoryBuild(repository, build: repositoryBuild.build))
         }, label: {
             HStack {
                 VStack(alignment: .leading) {

--- a/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
@@ -11,12 +11,13 @@ import SwiftUI
 struct TaskStatusCell: View {
 
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
     
     let taskStatus: TaskStatus
 
     var body: some View {
         Button(action: {
-            router.route(to: BuildTaskRoute(taskID: taskStatus.task_id))
+            router.route(to: routes.routeForTask(taskStatus.task_id))
         }, label: {
             HStack {
                 switch taskStatus.status {

--- a/Stampede/Stampede/Common/Extensions/View+Extension.swift
+++ b/Stampede/Stampede/Common/Extensions/View+Extension.swift
@@ -23,6 +23,7 @@ extension View {
             .environmentObject(CurrentTheme())
             .environmentObject(RepositoryListFixture())
             .environmentObject(Router())
+            .environmentObject(Routes())
             .environmentObject(StampedeService(provider: StampedeServiceFixtureProvider()))
     }
     #endif

--- a/Stampede/Stampede/Common/Models/StampedeError.swift
+++ b/Stampede/Stampede/Common/Models/StampedeError.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum StampedeError: Error {
   case parsing(description: String)
   case network(description: String)
+  case unknown
 }
 
 extension StampedeError: LocalizedError {
@@ -21,6 +22,8 @@ extension StampedeError: LocalizedError {
             return "Parsing error: \(description)"
         case .network(let description):
             return "Network error: \(description)"
+        case .unknown:
+            return nil
         }
     }
 }

--- a/Stampede/Stampede/Common/Router.swift
+++ b/Stampede/Stampede/Common/Router.swift
@@ -25,7 +25,8 @@ class Router: ObservableObject {
     }
 
     func route(to route: Route) {
-        guard let delegate = delegate, delegate.shouldRoute(to: route) else {
+        guard let delegate = delegate,
+              delegate.shouldRoute(to: route) else {
             return
         }
 

--- a/Stampede/Stampede/Common/Routes.swift
+++ b/Stampede/Stampede/Common/Routes.swift
@@ -52,6 +52,26 @@ class Routes: ObservableObject {
         return BuildTaskRoute(taskID: taskID)
     }
 
+    func route(for buildStatus: BuildStatus) -> Route {
+        return BuildRoute(build: buildStatus, buildID: nil)
+    }
+
+    func routeForBuildID(_ buildID: String) -> Route {
+        return BuildRoute(build: nil, buildID: buildID)
+    }
+
+    func routeForRepositoryBuild(_ repository: Repository, build: String) -> Route {
+        return RepositoryBuildDetailsRoute(repository: repository, build: build)
+    }
+
+    func routeForRepositorySourceDetails(_ repository: Repository, buildKey: String) -> Route {
+        return RepositorySourceDetailsRoute(repository: repository, buildKey: buildKey)
+    }
+
+    func routeSettingsDeveloperPersonaRoute() -> Route {
+        return SettingsDeveloperPersonaRoute()
+    }
+
     func routeForArtifact(_ taskID: String, artifact: TaskArtifact) -> Route {
         switch artifact.type {
         case "cloc":

--- a/Stampede/Stampede/Common/Routes.swift
+++ b/Stampede/Stampede/Common/Routes.swift
@@ -1,0 +1,65 @@
+//
+//  Routes.swift
+//  Stampede
+//
+//  Created by David House on 11/5/20.
+//  Copyright © 2020 David House. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct EmptyRoute: Route {
+    func makeFeature(_ dependencies: Dependencies) -> UIViewController {
+        return UIViewController()
+    }
+}
+
+class Routes: ObservableObject {
+
+    func route(for repository: Repository) -> Route {
+        return RepositoryRoute(repository: repository)
+    }
+
+    func route(for menuItem: MainMenuItem) -> Route {
+        switch menuItem {
+        case .live:
+            return MonitorLiveRoute()
+        case .activeBuilds:
+            return MonitorActiveBuildsRoute()
+        case .activeTasks:
+            return MonitorActiveTasksRoute()
+        case .queues:
+            return MonitorQueuesRoute()
+        case .historyBuilds:
+            return HistoryBuildsRoute()
+        case .historyTasks:
+            return HistoryTasksRoute()
+        case .settingsStampedeServer:
+            return SettingsStampedeServerRoute()
+        case .settingsRepositories:
+            return SettingsRepositoriesRoute()
+        case .settingsNotifications:
+            return SettingsNotificationsRoute()
+        case .settingsInfo:
+            return SettingsInfoRoute()
+        case .settingsDeveloper:
+            return SettingsDeveloperRoute()
+        }
+    }
+
+    func routeForTask(_ taskID: String) -> Route {
+        return BuildTaskRoute(taskID: taskID)
+    }
+
+    func routeForArtifact(_ taskID: String, artifact: TaskArtifact) -> Route {
+        switch artifact.type {
+        case "cloc":
+            return ArtifactClocRoute(taskID: taskID, title: artifact.title)
+        case "xcodebuild":
+            return ArtifactXcodebuildRoute(taskID: taskID, title: artifact.title)
+        default:
+            return EmptyRoute()
+        }
+    }
+}

--- a/Stampede/Stampede/Features/Build/BuildFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildFeature.swift
@@ -36,6 +36,7 @@ class BuildFeature: BaseFeature {
                                     BuildView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskFeature.swift
@@ -31,6 +31,7 @@ class BuildTaskFeature: BaseFeature {
                                     BuildTaskView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
@@ -121,14 +121,17 @@ struct BuildTaskArtifactsView: View {
     let taskID: String
     let artifacts: [TaskArtifact]
 
+    @EnvironmentObject var viewModel: BuildTaskViewModel
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     var body: some View {
         Section(header: Text("Artifacts")) {
             ForEach(artifacts, id: \.self) { artifact in
-                if artifact.type == "cloc" {
+                switch viewModel.categoryForArtifact(artifact) {
+                case .hasRoute:
                     Button(action: {
-                        router.route(to: ArtifactClocRoute(taskID: taskID, title: artifact.title))
+                        router.route(to: routes.routeForArtifact(taskID, artifact: artifact))
                     }, label: {
                         HStack {
                             PrimaryLabel(artifact.title)
@@ -137,18 +140,7 @@ struct BuildTaskArtifactsView: View {
                             Image(systemName: "chevron.right")
                         }
                     })
-                } else if artifact.type == "xcodebuild" {
-                    Button(action: {
-                        router.route(to: ArtifactXcodebuildRoute(taskID: taskID, title: artifact.title))
-                    }, label: {
-                        HStack {
-                            PrimaryLabel(artifact.title)
-                            Spacer()
-                            ValueLabel(artifact.type)
-                            Image(systemName: "chevron.right")
-                        }
-                    })
-                } else if artifact.type == "link" {
+                case .openURL:
                     HStack {
                         PrimaryLabel(artifact.title)
                         Spacer()
@@ -159,7 +151,7 @@ struct BuildTaskArtifactsView: View {
                             ValueLabel(artifact.type)
                         }
                     }
-                } else {
+                case .none:
                     HStack {
                         PrimaryLabel(artifact.title)
                         Spacer()

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskViewModel.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskViewModel.swift
@@ -8,5 +8,24 @@
 
 import Foundation
 import HouseKit
+import Combine
 
-class BuildTaskViewModel: BaseViewModel<TaskDetails> { }
+class BuildTaskViewModel: BaseViewModel<TaskDetails> {
+
+    enum ArtifactCategory {
+        case hasRoute
+        case openURL
+        case none
+    }
+
+    func categoryForArtifact(_ artifact: TaskArtifact) -> ArtifactCategory {
+        switch artifact.type {
+        case "cloc", "xcodebuild":
+            return .hasRoute
+        case "link":
+            return .openURL
+        default:
+            return .none
+        }
+    }
+}

--- a/Stampede/Stampede/Features/Build/BuildView.swift
+++ b/Stampede/Stampede/Features/Build/BuildView.swift
@@ -14,6 +14,7 @@ struct BuildView: View {
 
     @EnvironmentObject var viewModel: BuildViewModel
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     // MARK: - View
 
@@ -75,7 +76,7 @@ struct BuildView: View {
                 Section(header: Text("Tasks")) {
                     ForEach(buildStatus.tasks) { task in
                         Button(action: {
-                            router.route(to: BuildTaskRoute(taskID: task.task_id))
+                            router.route(to: routes.routeForTask(task.task_id))
                         }, label: {
                             TaskStatusCell(taskStatus: task)
                         })

--- a/Stampede/Stampede/Features/Build/BuildViewModel.swift
+++ b/Stampede/Stampede/Features/Build/BuildViewModel.swift
@@ -9,11 +9,10 @@
 import Foundation
 import SwiftUI
 import HouseKit
+import Combine
 
 class BuildViewModel: BaseViewModel<BuildStatus> {
 
-    // MARK: - Published
-    
     var statusImage: some View {
         switch state {
         case .results(let buildStatus):

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsFeature.swift
@@ -28,6 +28,7 @@ class HistoryBuildsFeature: BaseFeature {
                                     HistoryBuildsView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksFeature.swift
@@ -28,6 +28,7 @@ class HistoryTasksFeature: BaseFeature {
                                     HistoryTasksView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -14,6 +14,7 @@ struct HistoryTasksView: View {
     
     @EnvironmentObject var viewModel: HistoryTasksViewModel
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     // MARK: - Body
     
@@ -23,7 +24,7 @@ struct HistoryTasksView: View {
                 if tasks.count > 0 {
                     ForEach(tasks, id: \.self) { item in
                         Button(action: {
-                            router.route(to: BuildTaskRoute(taskID: item.task_id))
+                            router.route(to: routes.routeForTask(item.task_id))
                         }, label: {
                             TaskStatusCell(taskStatus: item)
                         })

--- a/Stampede/Stampede/Features/Main/MainFeature.swift
+++ b/Stampede/Stampede/Features/Main/MainFeature.swift
@@ -23,6 +23,7 @@ class MainFeature: BaseFeature {
                                     MainView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Main/MainView.swift
+++ b/Stampede/Stampede/Features/Main/MainView.swift
@@ -16,8 +16,7 @@ struct MainView: View {
     @EnvironmentObject var theme: CurrentTheme
     @EnvironmentObject var viewModel: MainViewModel
     @EnvironmentObject var router: Router
-
-    // MARK: - Private properties
+    @EnvironmentObject var routes: Routes
 
     // MARK: - View
 
@@ -27,7 +26,7 @@ struct MainView: View {
                 BaseView(viewModel: viewModel, content: { repositories in
                     ForEach(repositories, id: \.self) { item in
                         Button(action: {
-                            self.router.route(to: RepositoryRoute(repository: item))
+                            self.router.route(to: routes.route(for: item))
                         }, label: {
                             RepositoryCell(repository: item)
                         }).accessibilityIdentifier(item.id)
@@ -35,23 +34,19 @@ struct MainView: View {
                 })
             }
             Section(header: Text("Monitor")) {
-                FeatureRouteCell(title: "Live", route: MonitorLiveRoute())
-                FeatureRouteCell(title: "Active Builds", route: MonitorActiveBuildsRoute())
-                FeatureRouteCell(title: "Active Tasks", route: MonitorActiveTasksRoute())
-                FeatureRouteCell(title: "Queues", route: MonitorQueuesRoute())
+                ForEach(MainMenuItem.monitorItems, id: \.self) { item in
+                    FeatureRouteCell(title: item.rawValue, route: routes.route(for: item))
+                }
             }
             Section(header: Text("History")) {
-                FeatureRouteCell(title: "Builds", route: HistoryBuildsRoute())
-                FeatureRouteCell(title: "Tasks", route: HistoryTasksRoute())
+                ForEach(MainMenuItem.historyItems, id: \.self) { item in
+                    FeatureRouteCell(title: item.rawValue, route: routes.route(for: item))
+                }
             }
             Section(header: Text("Settings")) {
-                FeatureRouteCell(title: "Stampede Server", route: SettingsStampedeServerRoute())
-                FeatureRouteCell(title: "Repositories", route: SettingsRepositoriesRoute())
-                FeatureRouteCell(title: "Notifications", route: SettingsNotificationsRoute())
-                FeatureRouteCell(title: "Info", route: SettingsInfoRoute())
-                #if DEBUG
-                FeatureRouteCell(title: "Developer", route: SettingsDeveloperRoute())
-                #endif
+                ForEach(MainMenuItem.settingsItems, id: \.self) { item in
+                    FeatureRouteCell(title: item.rawValue, route: routes.route(for: item))
+                }
             }
         }.listStyle(GroupedListStyle())
     }
@@ -65,14 +60,14 @@ struct MainView_Previews: PreviewProvider, Previewable {
     }
 
     static var defaultViewModel: PreviewData<MainViewModel> {
-        PreviewData(id: "someResults", viewModel: MainViewModel(state: .results(Repository.someRepositories)))
+        PreviewData(id: "someResults", viewModel: MainViewModel.defaultViewModel)
     }
 
     static var alternateViewModels: [PreviewData<MainViewModel>] {
         [
-            PreviewData(id: "empty", viewModel: MainViewModel(state: .results([]))),
-            PreviewData(id: "loading", viewModel: MainViewModel(state: .loading)),
-            PreviewData(id: "networkError", viewModel: MainViewModel(state: .networkError(.network(description: "Some network error"))))
+            PreviewData(id: "empty", viewModel: MainViewModel.empty),
+            PreviewData(id: "loading", viewModel: MainViewModel.loading),
+            PreviewData(id: "networkError", viewModel: MainViewModel.networkError)
         ]
     }
 

--- a/Stampede/Stampede/Features/Main/MainViewModel.swift
+++ b/Stampede/Stampede/Features/Main/MainViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 import Combine
 import HouseKit
 
-enum MainMenuItem: String {
+enum MainMenuItem: String, CaseIterable {
     case live = "Live"
     case activeBuilds = "Active Builds"
     case activeTasks = "Active Tasks"

--- a/Stampede/Stampede/Features/Main/MainViewModel.swift
+++ b/Stampede/Stampede/Features/Main/MainViewModel.swift
@@ -11,4 +11,37 @@ import SwiftUI
 import Combine
 import HouseKit
 
+enum MainMenuItem: String {
+    case live = "Live"
+    case activeBuilds = "Active Builds"
+    case activeTasks = "Active Tasks"
+    case queues = "Queues"
+    case historyBuilds = "Builds"
+    case historyTasks = "Tasks"
+    case settingsStampedeServer = "Stampede Server"
+    case settingsRepositories = "Repositories"
+    case settingsNotifications = "Notifications"
+    case settingsInfo = "Info"
+    case settingsDeveloper = "Developer"
+
+    static let monitorItems: [MainMenuItem] = [.live, .activeBuilds, .activeTasks, .queues]
+    static let historyItems: [MainMenuItem] = [.historyBuilds, .historyTasks]
+    static let settingsItems: [MainMenuItem] = {
+        #if DEBUG
+            return [MainMenuItem.settingsStampedeServer, MainMenuItem.settingsRepositories, MainMenuItem.settingsNotifications, MainMenuItem.settingsInfo, MainMenuItem.settingsDeveloper]
+        #else
+            return [MainMenuItem.settingsStampedeServer, MainMenuItem.settingsRepositories, MainMenuItem.settingsNotifications, MainMenuItem.settingsInfo]
+        #endif
+    }()
+}
+
 class MainViewModel: BaseViewModel<[Repository]> { }
+
+#if DEBUG
+extension MainViewModel {
+    static let defaultViewModel = MainViewModel(state: .results(Repository.someRepositories))
+    static let loading = MainViewModel(state: .loading)
+    static let networkError = MainViewModel(state: .networkError(.network(description: "Some service error")))
+    static let empty = MainViewModel(state: .results([]))
+}
+#endif

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsFeature.swift
@@ -28,6 +28,7 @@ class MonitorActiveBuildsFeature: BaseFeature {
                                     MonitorActiveBuildsView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksFeature.swift
@@ -35,6 +35,7 @@ class MonitorActiveTasksFeature: BaseFeature {
                                     MonitorActiveTasksView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
     

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
@@ -14,6 +14,7 @@ struct MonitorActiveTasksView: View {
     
     @EnvironmentObject var viewModel: MonitorActiveTasksViewModel
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
 
     // MARK: - Body
     
@@ -23,7 +24,7 @@ struct MonitorActiveTasksView: View {
                 if tasks.count > 0 {
                     ForEach(tasks, id: \.self) { item in
                         Button(action: {
-                            router.route(to: BuildTaskRoute(taskID: item.task_id))
+                            router.route(to: routes.routeForTask(item.task_id))
                         }, label: {
                             TaskStatusCell(taskStatus: item)
                         })

--- a/Stampede/Stampede/Features/Settings/Developer/SettingsDeveloperFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Developer/SettingsDeveloperFeature.swift
@@ -29,6 +29,7 @@ class SettingsDeveloperFeature: BaseFeature {
                                     SettingsDeveloperView()
                                     .environmentObject(viewModel)
                                     .environmentObject(router)
+                                    .environmentObject(routes)
                                     .dependenciesToEnvironment(dependencies))
     }
 

--- a/Stampede/Stampede/Features/Settings/Developer/SettingsDeveloperView.swift
+++ b/Stampede/Stampede/Features/Settings/Developer/SettingsDeveloperView.swift
@@ -14,12 +14,13 @@ struct SettingsDeveloperView: View {
 
     @EnvironmentObject var theme: CurrentTheme
     @EnvironmentObject var router: Router
+    @EnvironmentObject var routes: Routes
     @EnvironmentObject var viewModel: SettingsDeveloperViewModel
 
     var body: some View {
         List {
             Button(action: {
-                router.route(to: SettingsDeveloperPersonaRoute())
+                router.route(to: routes.routeSettingsDeveloperPersonaRoute())
             }, label: {
                 HStack {
                     PrimaryLabel("Fixture Persona")


### PR DESCRIPTION
This PR refactors the routes again so that views don't directly know about the routes that should be taken. Instead, there is a `Routes` class that can generate a route based on a model such as a Repository. This class is added via the Environment from the Feature, so features can use the general `Routes` class or they can customize the routes the view will take by injecting a different class.

closes #85 