### PR TITLE
✨ New navbar for select repository

### DIFF
--- a/.stampede.yaml
+++ b/.stampede.yaml
@@ -12,14 +12,14 @@ pullrequests:
         projectFolder: Stampede
         scheme: Stampede
         project: Stampede
-        xcodeVersion: Xcode-beta.app
+        xcodeVersion: Xcode.app
         simulator: iPhone 11
     - id: ui-tests-xcode
       config:
         projectFolder: Stampede
         scheme: StampedeUITests
         project: Stampede
-        xcodeVersion: Xcode-beta.app
+        xcodeVersion: Xcode.app
         simulator: iPhone 11
     - id: lines-of-code
       config:
@@ -40,7 +40,7 @@ branches:
           projectFolder: Stampede
           scheme: Stampede
           project: Stampede
-          xcodeVersion: Xcode-beta.app
+          xcodeVersion: Xcode.app
           productName: Stampede
           infoPlist: Stampede/Info.plist
       - id: lines-of-code
@@ -54,14 +54,14 @@ branches:
           projectFolder: Stampede
           scheme: Stampede
           project: Stampede
-          xcodeVersion: Xcode-beta.app
+          xcodeVersion: Xcode.app
           simulator: iPhone 11
       - id: ui-tests-xcode
         config:
           projectFolder: Stampede
           scheme: StampedeUITests
           project: Stampede
-          xcodeVersion: Xcode-beta.app
+          xcodeVersion: Xcode.app
           simulator: iPhone 11
     notifications:
       all:

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryFeature.swift
@@ -43,11 +43,21 @@ class SelectRepositoryFeature: BaseFeature {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = "Add Favorite"
+        title = "Select Favorite"
+        modalPresentationStyle = .fullScreen
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(SelectRepositoryFeature.didSelectCancel(sender:)))
+        navigationItem.leftBarButtonItem = cancelButton
         navigationItem.largeTitleDisplayMode = .automatic
     }
     
     override func viewDidAppear(_ animated: Bool) {
         viewModel.publisher = dependencies.service.fetchRepositoriesPublisher()
+    }
+    
+    // MARK: - Private Methods
+    
+    @objc
+    private func didSelectCancel(sender: Any) {
+        dismiss(animated: true, completion: {})
     }
 }

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
@@ -37,7 +37,7 @@ struct SelectRepositoryView: View {
             List {
                 if repositories.count > 0 {
                     ForEach(repositories, id: \.self) { item in
-                        RepositoryCell(repository: item)
+                        FavoriteRepositoryCell(repository: item)
                             .contentShape(Rectangle())
                             .onTapGesture(perform: {
                                 delegate?.didSelectRepository(item)

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesFeature.swift
@@ -53,7 +53,8 @@ class SettingsRepositoriesFeature: BaseFeature {
     @objc
     private func didSelectAdd(sender: Any) {
         let selectRepository = SelectRepositoryFeature(dependencies: dependencies, delegate: self)
-        present(selectRepository, animated: true) { }
+        let selectRepositoryNav = UINavigationController(rootViewController: selectRepository)
+        present(selectRepositoryNav, animated: true) { }
     }
 
     private func reloadList() {


### PR DESCRIPTION
This PR adds a navbar and cancel button to the select repository screen. This fixes an issue with closing this popup on macOS.

closes #87 
