### PR TITLE
♻️ Updated Queue Summary API

### DIFF
--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorLive/MonitorLiveViewModelTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorLive/MonitorLiveViewModelTests.swift
@@ -117,12 +117,12 @@ class MonitorLiveViewModelTests: XCTestCase {
     }
 
     func testThatReceivingQueuesUpdatesTheQueueDepths() {
-        let result: [QueueSummary] = [
+        let result: QueueSummaries = QueueSummaries(taskQueues: [
             QueueSummary(queue: "someQueue", stats: QueueSummaryStats(waiting: 12, active: 0, completed: 0, failed: 0, delayed: 0, paused: 0))
-        ]
+        ], systemQueues: [])
         let expectation = XCTestExpectation(description: "waiting on publisher")
         viewModel.queuesPublisher =
-            AnyPublisher<[QueueSummary], ServiceError>(Future<[QueueSummary], ServiceError> { promise in promise(.success(result))})
+            AnyPublisher<QueueSummaries, ServiceError>(Future<QueueSummaries, ServiceError> { promise in promise(.success(result))})
         viewModel.startMonitoring()
         let cancellable = viewModel.$queueDepths.sink(receiveCompletion: { _ in
             print("received completion")
@@ -140,12 +140,12 @@ class MonitorLiveViewModelTests: XCTestCase {
     }
 
     func testThatReceivingAnErrorDoesNotModifyTheDepthList() {
-        let result: [QueueSummary] = [
+        let result: QueueSummaries = QueueSummaries(taskQueues: [
             QueueSummary(queue: "someQueue", stats: QueueSummaryStats(waiting: 12, active: 0, completed: 0, failed: 0, delayed: 0, paused: 0))
-        ]
+        ], systemQueues: [])
         let expectation = XCTestExpectation(description: "waiting on publisher")
         viewModel.queuesPublisher =
-            AnyPublisher<[QueueSummary], ServiceError>(Future<[QueueSummary], ServiceError> { promise in promise(.success(result))})
+            AnyPublisher<QueueSummaries, ServiceError>(Future<QueueSummaries, ServiceError> { promise in promise(.success(result))})
         viewModel.startMonitoring()
         let cancellable = viewModel.$queueDepths.sink(receiveCompletion: { _ in
             print("received completion")
@@ -163,7 +163,7 @@ class MonitorLiveViewModelTests: XCTestCase {
 
         let nextExpectation = XCTestExpectation(description: "waiting on publisher")
         viewModel.queuesPublisher =
-            AnyPublisher<[QueueSummary], ServiceError>(Future<[QueueSummary], ServiceError> { promise in promise(.failure(.network(description: "some network error")))})
+            AnyPublisher<QueueSummaries, ServiceError>(Future<QueueSummaries, ServiceError> { promise in promise(.failure(.network(description: "some network error")))})
         viewModel.startMonitoring()
         let nextCancellable = viewModel.$queueDepths.sink(receiveCompletion: { _ in
             print("received completion")

--- a/Stampede/Stampede/Common/Models/QueueSummary.swift
+++ b/Stampede/Stampede/Common/Models/QueueSummary.swift
@@ -32,7 +32,12 @@ public struct QueueSummary: Codable, Equatable, Identifiable, Hashable {
     }
 }
 
-typealias QueueSummaryResponsePublisher = AnyPublisher<[QueueSummary], ServiceError>
+public struct QueueSummaries: Codable, Equatable {
+    public let taskQueues: [QueueSummary]
+    public let systemQueues: [QueueSummary]
+}
+
+typealias QueueSummaryResponsePublisher = AnyPublisher<[QueueSummaries], ServiceError>
 
 #if DEBUG
 
@@ -46,6 +51,10 @@ extension QueueSummary {
                                 QueueSummary.oneWaiting,
                                 QueueSummary.moreWaiting,
                                 QueueSummary.alotWaiting]
+}
+
+extension QueueSummaries {
+    public static let someSummaries = QueueSummaries(taskQueues: QueueSummary.someSummaries, systemQueues: QueueSummary.someSummaries)
 }
 
 #endif

--- a/Stampede/Stampede/Common/StampedeAPI/Persona/ErrorPersona.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/Persona/ErrorPersona.swift
@@ -27,7 +27,7 @@ class ErrorPersona: Persona {
         .error(.network(description: "some network error happened"))
     }
 
-    var queues: FixtureResponse<[QueueSummary]> {
+    var queues: FixtureResponse<QueueSummaries> {
         .error(.network(description: "some network error happened"))
     }
 

--- a/Stampede/Stampede/Common/StampedeAPI/Persona/HappyPersona.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/Persona/HappyPersona.swift
@@ -27,8 +27,8 @@ class HappyPersona: Persona {
         .results(BuildStatus.activeBuilds)
     }
 
-    var queues: FixtureResponse<[QueueSummary]> {
-        .results(QueueSummary.someSummaries)
+    var queues: FixtureResponse<QueueSummaries> {
+        .results(QueueSummaries.someSummaries)
     }
 
     var workerStatus: FixtureResponse<[WorkerStatus]> {

--- a/Stampede/Stampede/Common/StampedeAPI/Persona/LoadingPersona.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/Persona/LoadingPersona.swift
@@ -26,7 +26,7 @@ class LoadingPersona: Persona {
         .loading
     }
 
-    var queues: FixtureResponse<[QueueSummary]> {
+    var queues: FixtureResponse<QueueSummaries> {
         .loading
     }
 

--- a/Stampede/Stampede/Common/StampedeAPI/Persona/Persona.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/Persona/Persona.swift
@@ -14,7 +14,7 @@ protocol Persona {
     var repositoryActiveBuilds: FixtureResponse<[BuildStatus]> { get }
     var repositoryBuilds: FixtureResponse<[RepositoryBuild]> { get }
     var activeBuilds: FixtureResponse<[BuildStatus]> { get }
-    var queues: FixtureResponse<[QueueSummary]> { get }
+    var queues: FixtureResponse<QueueSummaries> { get }
     var workerStatus: FixtureResponse<[WorkerStatus]> { get }
     var activeTasks: FixtureResponse<[TaskStatus]> { get }
     var historyTasks: FixtureResponse<[TaskStatus]> { get }

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeService.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeService.swift
@@ -74,7 +74,7 @@ public class StampedeService: ObservableObject {
         return provider.fetchAdminQueuesPublisher()
     }
 
-    public func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>? {
+    public func fetchMonitorQueuesPublisher() -> AnyPublisher<QueueSummaries, ServiceError>? {
         return provider.fetchMonitorQueuesPublisher()
     }
 

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceFixtureProvider.swift
@@ -121,7 +121,7 @@ class StampedeServiceFixtureProvider: FixtureProvider, StampedeServiceProvider {
         return fetchPublisher(persona.activeBuilds)
     }
     
-    func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>? {
+    func fetchMonitorQueuesPublisher() -> AnyPublisher<QueueSummaries, ServiceError>? {
         fetchMonitorQueuesPublisherCalled = true
         guard let host = host, !host.contains("error") else {
             return fetchPublisher(.error(.network(description: "some network error happened")))

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceNetworkProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceNetworkProvider.swift
@@ -81,9 +81,9 @@ public class StampedeServiceNetworkProvider: NetworkProvider, StampedeServicePro
         return request(url: StampedeAPIEndpoint.artifactContents(taskID, title).url(host: host))
     }
 
-    public func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>? {
+    public func fetchMonitorQueuesPublisher() -> AnyPublisher<QueueSummaries, ServiceError>? {
         guard let host = host else {
-            return AnyPublisher<[QueueSummary], ServiceError>(Future<[QueueSummary], ServiceError> { promise in promise(.failure(.network(description: "Host not provided")))})
+            return AnyPublisher<QueueSummaries, ServiceError>(Future<QueueSummaries, ServiceError> { promise in promise(.failure(.network(description: "Host not provided")))})
         }
         return request(url: StampedeAPIEndpoint.monitorQueues.url(host: host))
     }

--- a/Stampede/Stampede/Common/StampedeAPI/StampedeServiceProvider.swift
+++ b/Stampede/Stampede/Common/StampedeAPI/StampedeServiceProvider.swift
@@ -30,7 +30,7 @@ public protocol StampedeServiceProvider {
 
     // Monitor
     func fetchActiveBuildsPublisher() -> AnyPublisher<[BuildStatus], ServiceError>?
-    func fetchMonitorQueuesPublisher() -> AnyPublisher<[QueueSummary], ServiceError>?
+    func fetchMonitorQueuesPublisher() -> AnyPublisher<QueueSummaries, ServiceError>?
     func fetchWorkerStatusPublisher() -> AnyPublisher<[WorkerStatus], ServiceError>?
     func fetchActiveTasksPublisher() -> AnyPublisher<[TaskStatus], ServiceError>?
 

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
@@ -19,15 +19,25 @@ struct MonitorQueuesView: View {
     var body: some View {
         BaseView(viewModel: viewModel, content: { queues in
             List {
-                if queues.count > 0 {
-                    ForEach(queues, id: \.self) { item in
-                        QueueSummaryCell(queueSummary: item)
+                Section(header: Text("Task Queues")) {
+                    if queues.taskQueues.count > 0 {
+                        ForEach(queues.taskQueues, id: \.self) { item in
+                            QueueSummaryCell(queueSummary: item)
+                        }
+                    } else {
+                        Text("No queues found")
                     }
-                } else {
-                    Text("No queues found")
+                }
+                Section(header: Text("System Queues")) {
+                        if queues.systemQueues.count > 0 {
+                            ForEach(queues.systemQueues, id: \.self) { item in
+                                QueueSummaryCell(queueSummary: item)
+                            }
+                        } else {
+                            Text("No queues found")
+                        }
                 }
             }
-            .listStyle(DefaultListStyle())
         })
     }
 }

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesViewModel.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesViewModel.swift
@@ -9,12 +9,12 @@
 import Foundation
 import HouseKit
 
-class MonitorQueuesViewModel: BaseViewModel<[QueueSummary]> { }
+class MonitorQueuesViewModel: BaseViewModel<QueueSummaries> { }
 
 #if DEBUG
 extension MonitorQueuesViewModel {
     static let loading = MonitorQueuesViewModel(state: .loading)
     static let networkError = MonitorQueuesViewModel(state: .networkError(.network(description: "some error")))
-    static let someQueues = MonitorQueuesViewModel(state: .results(QueueSummary.someSummaries))
+    static let someQueues = MonitorQueuesViewModel(state: .results(QueueSummaries.someSummaries))
 }
 #endif


### PR DESCRIPTION
This PR updates the Queue Summary API response & Monitor Queues view to the latest API spec. Now the system will return `taskQueues` and `systemQueues` separately. These need to be displayed differently in the UI.

closes #89 
