### PR TITLE
✨ Task details supports installplist artifact

### DIFF
--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskView.swift
@@ -151,6 +151,17 @@ struct BuildTaskArtifactsView: View {
                             ValueLabel(artifact.type)
                         }
                     }
+                case .installplist:
+                    HStack {
+                        PrimaryLabel(artifact.title)
+                        Spacer()
+                        if let url = viewModel.appInstallURL(artifact) {
+                            Link("Install", destination: url)
+                            Image(systemName: "chevron.right")
+                        } else {
+                            ValueLabel(artifact.type)
+                        }
+                    }
                 case .none:
                     HStack {
                         PrimaryLabel(artifact.title)

--- a/Stampede/Stampede/Features/Build/BuildTask/BuildTaskViewModel.swift
+++ b/Stampede/Stampede/Features/Build/BuildTask/BuildTaskViewModel.swift
@@ -16,6 +16,7 @@ class BuildTaskViewModel: BaseViewModel<TaskDetails> {
         case hasRoute
         case openURL
         case none
+        case installplist
     }
 
     func categoryForArtifact(_ artifact: TaskArtifact) -> ArtifactCategory {
@@ -24,8 +25,25 @@ class BuildTaskViewModel: BaseViewModel<TaskDetails> {
             return .hasRoute
         case "link":
             return .openURL
+        case "installplist":
+            return .installplist
         default:
             return .none
+        }
+    }
+
+    func appInstallURL(_ artifact: TaskArtifact) -> URL? {
+        switch artifact.type {
+        case "installplist":
+            if let urlString = artifact.url,
+               let encodedUrl = urlString.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+               let installUrl = URL(string: "itms-services://?action=download-manifest&url=" + encodedUrl) {
+                return installUrl
+            } else {
+                return nil
+            }
+        default:
+            return nil
         }
     }
 }


### PR DESCRIPTION
App now supports opening the `itms-services` url that contains an app install plist.

closes #61 