### PR TITLE
♻️ Use Label component views instead of Text

### DIFF
--- a/Stampede/Stampede/Common/BaseSubView.swift
+++ b/Stampede/Stampede/Common/BaseSubView.swift
@@ -21,7 +21,7 @@ struct BaseSubView<T, Content: View>: View {
     var body: some View {
         switch state {
         case .loading:
-            Text("Loading...")
+            PrimaryLabel("Loading...")
         case .networkError(let error):
             NetworkErrorView(error: error)
         case .results(let object):

--- a/Stampede/Stampede/Common/BaseView.swift
+++ b/Stampede/Stampede/Common/BaseView.swift
@@ -21,7 +21,7 @@ struct BaseView<T, Content: View>: View {
     var body: some View {
         switch viewModel.state {
         case .loading:
-            Text("Loading...")
+            PrimaryLabel("Loading...")
         case .networkError(let error):
             NetworkErrorView(error: error)
         case .results(let object):

--- a/Stampede/Stampede/Features/Build/BuildView.swift
+++ b/Stampede/Stampede/Features/Build/BuildView.swift
@@ -23,53 +23,53 @@ struct BuildView: View {
             List {
                 Section(header: Text("Build Details")) {
                     HStack {
-                        Text("Owner")
+                        PrimaryLabel("Owner")
                         Spacer()
-                        Text(buildStatus.buildDetails.owner)
+                        ValueLabel(buildStatus.buildDetails.owner)
                     }
 
                     HStack {
-                        Text("Repository")
+                        PrimaryLabel("Repository")
                         Spacer()
-                        Text(buildStatus.buildDetails.repository)
+                        ValueLabel(buildStatus.buildDetails.repository)
                     }
 
                     HStack {
-                        Text("Build Key")
+                        PrimaryLabel("Build Key")
                         Spacer()
-                        Text(buildStatus.buildDetails.build_key)
+                        ValueLabel(buildStatus.buildDetails.build_key)
                     }
 
                     HStack {
-                        Text("Build #")
+                        PrimaryLabel("Build #")
                         Spacer()
-                        Text("\(buildStatus.buildDetails.build)")
+                        ValueLabel("\(buildStatus.buildDetails.build)")
                     }
 
                     HStack {
-                        Text("Status")
+                        PrimaryLabel("Status")
                         Spacer()
-                        Text(buildStatus.buildDetails.status)
+                        ValueLabel(buildStatus.buildDetails.status)
                     }
 
                     HStack {
-                        Text("Started At")
+                        PrimaryLabel("Started At")
                         Spacer()
                         Text(buildStatus.buildDetails.started_at, style: .time)
                     }
 
                     if let completed_at = buildStatus.buildDetails.completed_at {
                         HStack {
-                            Text("Completed At")
+                            PrimaryLabel("Completed At")
                             Spacer()
                             Text(completed_at, style: .time)
                         }
                     }
 
                     HStack {
-                        Text("Duration")
+                        PrimaryLabel("Duration")
                         Spacer()
-                        Text(buildStatus.buildDetails.duration)
+                        ValueLabel(buildStatus.buildDetails.duration)
                     }
                 }
 

--- a/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
+++ b/Stampede/Stampede/Features/History/Builds/HistoryBuildsView.swift
@@ -25,7 +25,7 @@ struct HistoryBuildsView: View {
                         BuildDetailsCell(buildDetails: item)
                     }
                 } else {
-                    Text("No builds found")
+                    PrimaryLabel("No builds found")
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
+++ b/Stampede/Stampede/Features/History/Tasks/HistoryTasksView.swift
@@ -30,7 +30,7 @@ struct HistoryTasksView: View {
                         })
                     }
                 } else {
-                    Text("No tasks found")
+                    PrimaryLabel("No tasks found")
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsView.swift
@@ -25,7 +25,7 @@ struct MonitorActiveBuildsView: View {
                         BuildStatusCell(buildStatus: item)
                     }
                 } else {
-                    Text("No active builds found")
+                    PrimaryLabel("No active builds found")
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksView.swift
@@ -30,7 +30,7 @@ struct MonitorActiveTasksView: View {
                         })
                     }
                 } else {
-                    Text("No active tasks found")
+                    PrimaryLabel("No active tasks found")
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
+++ b/Stampede/Stampede/Features/Monitor/MonitorQueues/MonitorQueuesView.swift
@@ -25,7 +25,7 @@ struct MonitorQueuesView: View {
                             QueueSummaryCell(queueSummary: item)
                         }
                     } else {
-                        Text("No queues found")
+                        PrimaryLabel("No queues found")
                     }
                 }
                 Section(header: Text("System Queues")) {
@@ -34,7 +34,7 @@ struct MonitorQueuesView: View {
                                 QueueSummaryCell(queueSummary: item)
                             }
                         } else {
-                            Text("No queues found")
+                            PrimaryLabel("No queues found")
                         }
                 }
             }

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryBuildDetails/RepositoryBuildDetailsView.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryBuildDetails/RepositoryBuildDetailsView.swift
@@ -26,7 +26,7 @@ struct RepositoryBuildDetailsView: View {
                             BuildStatusCell(buildStatus: item)
                         }
                     } else {
-                        Text("No active builds found")
+                        PrimaryLabel("No active builds found")
                     }
                 })
             }
@@ -38,7 +38,7 @@ struct RepositoryBuildDetailsView: View {
                             BuildDetailsCell(buildDetails: item)
                         }
                     } else {
-                        Text("No recent builds found")
+                        PrimaryLabel("No recent builds found")
                     }
                 })
             }

--- a/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
+++ b/Stampede/Stampede/Features/Repositories/Repository/RepositoryView.swift
@@ -28,7 +28,7 @@ struct RepositoryView: View {
                             BuildStatusCell(buildStatus: item)
                         }
                     } else {
-                        Text("No active builds found")
+                        PrimaryLabel("No active builds found")
                     }
                 })
             }
@@ -40,7 +40,7 @@ struct RepositoryView: View {
                             RepositoryBuildCell(repository: viewModel.repository, repositoryBuild: item)
                         }
                     } else {
-                        Text("No repository builds found")
+                        PrimaryLabel("No repository builds found")
                     }
                 })
             }
@@ -52,7 +52,7 @@ struct RepositoryView: View {
                             BuildKeyCell(repository: viewModel.repository, buildKey: item)
                         }
                     } else {
-                        Text("No branch builds found")
+                        PrimaryLabel("No branch builds found")
                     }
                 })
             }
@@ -64,7 +64,7 @@ struct RepositoryView: View {
                             BuildKeyCell(repository: viewModel.repository, buildKey: item)
                         }
                     } else {
-                        Text("No release builds found")
+                        PrimaryLabel("No release builds found")
                     }
                 })
             }
@@ -76,7 +76,7 @@ struct RepositoryView: View {
                             BuildKeyCell(repository: viewModel.repository, buildKey: item)
                         }
                     } else {
-                        Text("No pull request builds found")
+                        PrimaryLabel("No pull request builds found")
                     }
                 })
             }

--- a/Stampede/Stampede/Features/Settings/Info/SettingsInfoView.swift
+++ b/Stampede/Stampede/Features/Settings/Info/SettingsInfoView.swift
@@ -20,8 +20,8 @@ struct SettingsInfoView: View {
 
     var body: some View {
         List {
-            Text("Version: \(viewModel.appVersion)")
-            Text("Build: \(viewModel.appBuildNumber)")
+            PrimaryLabel("Version: \(viewModel.appVersion)")
+            PrimaryLabel("Build: \(viewModel.appBuildNumber)")
             Button("https://stampedeci.com", action: {
                 UIApplication.shared.open(URL(string: "https://stampedeci.com")!, options: [:]) { _ in
 

--- a/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SelectRepository/SelectRepositoryView.swift
@@ -44,7 +44,7 @@ struct SelectRepositoryView: View {
                             })
                     }
                 } else {
-                    Text("No repositories selected")
+                    PrimaryLabel("No repositories selected")
                 }
             }
             .listStyle(DefaultListStyle())

--- a/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
+++ b/Stampede/Stampede/Features/Settings/Repositories/SettingsRepositoriesView.swift
@@ -42,7 +42,7 @@ struct SettingsRepositoriesView: View {
                         self.delegate?.didDeleteRepositories(indexSet)
                     })
                 } else {
-                    Text("No repositories selected")
+                    PrimaryLabel("No repositories selected")
                 }
             }
             .listStyle(DefaultListStyle())


### PR DESCRIPTION
This PR refactors some of the views that were using `Text` directly and now they are using the correct `Label` component.

closes #102 
