### PR TITLE
♻️ Moved task status icon to its own view

### DIFF
--- a/Stampede/Stampede-Tests/Common/ComponentViews/Images/TaskStatusIconTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Images/TaskStatusIconTests.swift
@@ -1,0 +1,17 @@
+//
+//  TaskStatusIconTests.swift
+//  Stampede-Tests
+//
+//  Created by David House on 2/20/21.
+//  Copyright © 2021 David House. All rights reserved.
+//
+
+@testable import Stampede
+import XCTest
+
+class TaskStatusIconTests: XCTestCase {
+
+    func testCapturePreviews() {
+        capturedPreviews(TaskStatusIcon_Previews.capturedPreviews(title: "TaskStatusIcon"))
+    }
+}

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -215,6 +215,7 @@
 		C3F7668B245B704D0022E485 /* NetworkErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F7668A245B704D0022E485 /* NetworkErrorView.swift */; };
 		C3F83EC6239407290057A0FB /* MainFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F83EC5239407290057A0FB /* MainFeature.swift */; };
 		DC0D04DD25E1816A00418EBA /* TaskStatusIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0D04DC25E1816A00418EBA /* TaskStatusIcon.swift */; };
+		DC0D04E325E19F1A00418EBA /* TaskStatusIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0D04E225E19F1A00418EBA /* TaskStatusIconTests.swift */; };
 		DCF1607225AE6120009321A1 /* SectionHeaderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF1607125AE6120009321A1 /* SectionHeaderLabel.swift */; };
 		DCF1607725AE62FC009321A1 /* SectionHeaderLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF1607625AE62FC009321A1 /* SectionHeaderLabelTests.swift */; };
 /* End PBXBuildFile section */
@@ -449,6 +450,7 @@
 		C3F7668A245B704D0022E485 /* NetworkErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorView.swift; sourceTree = "<group>"; };
 		C3F83EC5239407290057A0FB /* MainFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFeature.swift; sourceTree = "<group>"; };
 		DC0D04DC25E1816A00418EBA /* TaskStatusIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStatusIcon.swift; sourceTree = "<group>"; };
+		DC0D04E225E19F1A00418EBA /* TaskStatusIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStatusIconTests.swift; sourceTree = "<group>"; };
 		DCF1607125AE6120009321A1 /* SectionHeaderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderLabel.swift; sourceTree = "<group>"; };
 		DCF1607625AE62FC009321A1 /* SectionHeaderLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderLabelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -509,6 +511,7 @@
 		941F25C623C2A39B00EC3E36 /* ComponentViews */ = {
 			isa = PBXGroup;
 			children = (
+				DC0D04E125E19E7D00418EBA /* Images */,
 				C3DDDC2325180A21005C8189 /* Cells */,
 				94DB4DFD247C479C001EF693 /* View */,
 				941F25D223C2A6B700EC3E36 /* Labels */,
@@ -1364,6 +1367,14 @@
 			path = Images;
 			sourceTree = "<group>";
 		};
+		DC0D04E125E19E7D00418EBA /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				DC0D04E225E19F1A00418EBA /* TaskStatusIconTests.swift */,
+			);
+			path = Images;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1657,6 +1668,7 @@
 				C3DDDC9425180FF4005C8189 /* SettingsRepositoriesFeatureTests.swift in Sources */,
 				C38BDD84254504F600CA9A48 /* FeatureRouteCellTests.swift in Sources */,
 				C3DDDC3225180A90005C8189 /* TaskStatusCellTests.swift in Sources */,
+				DC0D04E325E19F1A00418EBA /* TaskStatusIconTests.swift in Sources */,
 				C3DE1C712541C9DA009FA36D /* SettingsDeveloperPersonaFeatureTests.swift in Sources */,
 				C3DDDC7725180F06005C8189 /* HistoryBuildsFeatureTests.swift in Sources */,
 				C3DDDC5A25180C85005C8189 /* BuildTaskViewTests.swift in Sources */,

--- a/Stampede/Stampede.xcodeproj/project.pbxproj
+++ b/Stampede/Stampede.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		C3F76681245B0F300022E485 /* StampedeDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F76680245B0F300022E485 /* StampedeDefaults.swift */; };
 		C3F7668B245B704D0022E485 /* NetworkErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F7668A245B704D0022E485 /* NetworkErrorView.swift */; };
 		C3F83EC6239407290057A0FB /* MainFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F83EC5239407290057A0FB /* MainFeature.swift */; };
+		DC0D04DD25E1816A00418EBA /* TaskStatusIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0D04DC25E1816A00418EBA /* TaskStatusIcon.swift */; };
 		DCF1607225AE6120009321A1 /* SectionHeaderLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF1607125AE6120009321A1 /* SectionHeaderLabel.swift */; };
 		DCF1607725AE62FC009321A1 /* SectionHeaderLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF1607625AE62FC009321A1 /* SectionHeaderLabelTests.swift */; };
 /* End PBXBuildFile section */
@@ -447,6 +448,7 @@
 		C3F76680245B0F300022E485 /* StampedeDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StampedeDefaults.swift; sourceTree = "<group>"; };
 		C3F7668A245B704D0022E485 /* NetworkErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorView.swift; sourceTree = "<group>"; };
 		C3F83EC5239407290057A0FB /* MainFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainFeature.swift; sourceTree = "<group>"; };
+		DC0D04DC25E1816A00418EBA /* TaskStatusIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStatusIcon.swift; sourceTree = "<group>"; };
 		DCF1607125AE6120009321A1 /* SectionHeaderLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderLabel.swift; sourceTree = "<group>"; };
 		DCF1607625AE62FC009321A1 /* SectionHeaderLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderLabelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -605,6 +607,7 @@
 		946DAD2A23BEC7C200053335 /* ComponentViews */ = {
 			isa = PBXGroup;
 			children = (
+				DC0D04DB25E1815400418EBA /* Images */,
 				C3F76689245B70380022E485 /* View */,
 				941F25BF23C23B2500EC3E36 /* List */,
 				C3126DA823BED8D700AC542F /* Buttons */,
@@ -1353,6 +1356,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		DC0D04DB25E1815400418EBA /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				DC0D04DC25E1816A00418EBA /* TaskStatusIcon.swift */,
+			);
+			path = Images;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1601,6 +1612,7 @@
 				C3816C7D248702AB00E6980B /* MonitorQueuesView.swift in Sources */,
 				C39E58F72540738900217743 /* Persona.swift in Sources */,
 				C34755EC24FC85BD009B1FBF /* BuildStatusCell.swift in Sources */,
+				DC0D04DD25E1816A00418EBA /* TaskStatusIcon.swift in Sources */,
 				94FE1F4724FB081500AE4ED4 /* RepositoryList.swift in Sources */,
 				94B571F024BBBECD00CA13A4 /* BuildDetails.swift in Sources */,
 				C3081AC624563CBE000C20F1 /* BuildFeature.swift in Sources */,

--- a/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Cells/TaskStatusCell.swift
@@ -20,17 +20,7 @@ struct TaskStatusCell: View {
             router.route(to: routes.routeForTask(taskStatus.task_id))
         }, label: {
             HStack {
-                switch taskStatus.status {
-                case "in_progress":
-                    CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
-                default:
-                    switch taskStatus.conclusion {
-                    case "success":
-                        CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
-                    default:
-                        CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
-                    }
-                }
+                TaskStatusIcon(status: taskStatus.status, conclusion: taskStatus.conclusion)
                 VStack(alignment: .leading) {
                     PrimaryLabel(taskStatus.task)
                     SecondaryLabel(taskStatus.buildTitle ?? "")

--- a/Stampede/Stampede/Common/ComponentViews/Images/TaskStatusIcon.swift
+++ b/Stampede/Stampede/Common/ComponentViews/Images/TaskStatusIcon.swift
@@ -1,0 +1,54 @@
+//
+//  TaskStatusIcon.swift
+//  Stampede
+//
+//  Created by David House on 2/20/21.
+//  Copyright © 2021 David House. All rights reserved.
+//
+
+import SwiftUI
+
+struct TaskStatusIcon: View {
+    
+    let status: String
+    let conclusion: String?
+    
+    var body: some View {
+        switch status {
+        case "in_progress":
+            CurrentTheme.Icons.inProgress.image().font(Font.system(size: 32, weight: .regular))
+        default:
+            switch conclusion {
+            case "success":
+                CurrentTheme.Icons.success.image().font(Font.system(size: 32, weight: .regular))
+            default:
+                CurrentTheme.Icons.failure.image().font(Font.system(size: 32, weight: .regular))
+            }
+        }
+    }
+}
+
+
+#if DEBUG
+struct TaskStatusIcon_Previews: PreviewProvider, Previewable {
+    static var previews: some View {
+        debugPreviews
+    }
+
+    static var defaultViewModel: PreviewData<(String, String?)> {
+        PreviewData(id: "inprogress", viewModel: ("in_progress", nil))
+    }
+
+    static var alternateViewModels: [PreviewData<(String, String?)>] {
+        [
+            PreviewData(id: "inprogress", viewModel: ("in_progress", nil)),
+            PreviewData(id: "success", viewModel: ("success", "success")),
+            PreviewData(id: "failure", viewModel: ("completed", "failure"))
+        ]
+    }
+
+    static func create(from viewModel: (String, String?)) -> some View {
+        TaskStatusIcon(status: viewModel.0, conclusion: viewModel.1)
+    }
+}
+#endif


### PR DESCRIPTION
This PR moves the task status icon to its own View instead of being embedded inside the task status cell.

closes #109 
