### PR TITLE
🐛  Fixed compile errors in tests due to MainActor not being specified

### DIFF
--- a/Stampede/Stampede-Tests/Common/ComponentViews/Buttons/NavbarButtonTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Buttons/NavbarButtonTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class NavbarButtonTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Cells/BuildStatusCellTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Cells/BuildStatusCellTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class BuildStatusCellTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Cells/FavoriteRepositoryCellTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Cells/FavoriteRepositoryCellTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class FavoriteRepositoryCellTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Cells/FeatureRouteCellTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Cells/FeatureRouteCellTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class FeatureRouteCellTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Cells/RepositoryBuildCellTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Cells/RepositoryBuildCellTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class RepositoryBuildCellTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Cells/RepositoryCellTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Cells/RepositoryCellTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class RepositoryCellTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Cells/TaskStatusCellTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Cells/TaskStatusCellTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class TaskStatusCellTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Labels/PrimaryLabelTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Labels/PrimaryLabelTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class PrimaryLabelTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Labels/SecondaryLabelTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Labels/SecondaryLabelTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SecondaryLabelTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Labels/SectionHeaderLabelTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Labels/SectionHeaderLabelTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SectionHeaderLabelTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Labels/TimeLabelTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Labels/TimeLabelTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class TimeLabelTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/Labels/ValueLabelTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/Labels/ValueLabelTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class ValueLabelTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/List/EmptyListTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/List/EmptyListTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class EmptyListTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Common/ComponentViews/View/NetworkErrorViewTests.swift
+++ b/Stampede/Stampede-Tests/Common/ComponentViews/View/NetworkErrorViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class NetworkErrorViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Build/BuildTask/BuildTaskViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Build/BuildTask/BuildTaskViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class BuildTaskViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Build/BuildViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Build/BuildViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class BuildViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/History/Builds/HistoryBuildsViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/History/Builds/HistoryBuildsViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class HistoryBuildsViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/History/Tasks/HistoryTasksViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/History/Tasks/HistoryTasksViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class HistoryTasksViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveBuilds/MonitorActiveBuildsViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class MonitorActiveBuildsViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorActiveTasks/MonitorActiveTasksViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class MonitorActiveTasksViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Monitor/MonitorQueues/MonitorQueuesViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Monitor/MonitorQueues/MonitorQueuesViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class MonitorQueuesViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Repositories/Repository/RepositoryViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Repositories/Repository/RepositoryViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class RepositoryViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Repositories/RepositoryBuildDetails/RepositoryBuildDetailsViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Repositories/RepositoryBuildDetails/RepositoryBuildDetailsViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class RepositoryBuildDetailsViewTests: XCTestCase {
     func testCapturePreviews() {
         capturedPreviews(RepositoryBuildDetailsView_Previews.capturedPreviews(title: "RepositoryBuildDetailsView_Previews"))

--- a/Stampede/Stampede-Tests/Features/Repositories/RepositorySourceDetails/RepositorySourceDetailsViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Repositories/RepositorySourceDetails/RepositorySourceDetailsViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class RepositorySourceDetailsViewTests: XCTestCase {
     func testCapturePreviews() {
         capturedPreviews(RepositorySourceDetailsView_Previews.capturedPreviews(title: "RepositorySourceDetailsView_Previews"))

--- a/Stampede/Stampede-Tests/Features/Settings/Developer/Persona/SettingsDeveloperPersonaViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Developer/Persona/SettingsDeveloperPersonaViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SettingsDeveloperPersonaViewTests: XCTestCase {
     func testCapturePreviews() {
         capturedPreviews(SettingsDeveloperPersonaView_Previews.capturedPreviews(title: "SettingsDeveloperPersonaView_Previews"))

--- a/Stampede/Stampede-Tests/Features/Settings/Developer/SettingsDeveloperViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Developer/SettingsDeveloperViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SettingsDeveloperViewTests: XCTestCase {
     func testCapturePreviews() {
         capturedPreviews(SettingsDeveloperView_Previews.capturedPreviews(title: "SettingsDeveloperView_Previews"))

--- a/Stampede/Stampede-Tests/Features/Settings/Notifications/SettingsNotificationsViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Notifications/SettingsNotificationsViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SettingsNotificationsViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Settings/Repositories/SelectRepository/SelectRepositoryViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Repositories/SelectRepository/SelectRepositoryViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SelectRepositoryViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Settings/Repositories/SettingsRepositoriesViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/Repositories/SettingsRepositoriesViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SettingsRepositoriesViewTests: XCTestCase {
 
     func testCapturePreviews() {

--- a/Stampede/Stampede-Tests/Features/Settings/StampedeServer/SettingsStampedeServerViewTests.swift
+++ b/Stampede/Stampede-Tests/Features/Settings/StampedeServer/SettingsStampedeServerViewTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import Stampede
 
+@MainActor
 class SettingsStampedeServerViewTests: XCTestCase {
 
     func testCapturePreviews() {


### PR DESCRIPTION
This PR fixes some compile errors in the latest Xcode due to tests not including the `@MainActor` attribute.